### PR TITLE
Restrict Access to msr_whitelist

### DIFF
--- a/rpm/10-msr-safe.rules
+++ b/rpm/10-msr-safe.rules
@@ -1,1 +1,2 @@
 SUBSYSTEM=="msr_safe", GROUP="msr", MODE="0660"
+SUBSYSTEM=="msr_batch", GROUP="msr", MODE="0660"

--- a/rpm/10-msr-safe.rules
+++ b/rpm/10-msr-safe.rules
@@ -1,3 +1,1 @@
 SUBSYSTEM=="msr_safe", GROUP="msr", MODE="0660"
-SUBSYSTEM=="msr_batch", GROUP="msr", MODE="0660"
-SUBSYSTEM=="msr_whitelist", GROUP="msr", MODE="0660"


### PR DESCRIPTION
Normal users should only have access to the CPU msr-safe devices not msr_batch or msr_whitelist, which should require elevated permissions.