### PR TITLE
Use down_write/up_write in kernel 4.7 and newer in place of mutex_loc…

### DIFF
--- a/msr_entry.c
+++ b/msr_entry.c
@@ -58,7 +58,11 @@ static loff_t msr_seek(struct file *file, loff_t offset, int orig)
 	loff_t ret;
 	struct inode *inode = file->f_mapping->host;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,7,0)
+	down_write(&inode->i_rwsem);
+#else
 	mutex_lock(&inode->i_mutex);
+#endif
 	switch (orig) {
 	case SEEK_SET:
 		file->f_pos = offset;
@@ -71,7 +75,11 @@ static loff_t msr_seek(struct file *file, loff_t offset, int orig)
 	default:
 		ret = -EINVAL;
 	}
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,7,0)
+	up_write(&inode->i_rwsem);
+#else
 	mutex_unlock(&inode->i_mutex);
+#endif
 	return ret;
 }
 


### PR DESCRIPTION


This patch seems to fix #11 but somebody with more kernel experience should verify that the locking approach is correct.  Cheers.