### PR TITLE
Copy whitelist file to a temporary file before parsing by msrsave.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ Module.symvers
 *.mod.c
 *.unsigned
 modules.order
+msrsave/msrsave
+msrsave/msrsave_test

--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,40 @@
 obj-m += msr-safe.o 
 msr-safe-objs := msr_entry.o msr_whitelist.o msr-smp.o msr_batch.o
 
-all:
+all: msrsave/msrsave
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules 
 
 clean:
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+	rm -f msrsave/msrsave.o msrsave/msrsave msrsave/msrsave_test
+
+check: msrsave/msrsave_test
+	msrsave/msrsave_test
+
+msrsave/msrsave.o: msrsave/msrsave.c msrsave/msrsave.h
+
+msrsave/msrsave_main.o: msrsave/msrsave_main.c msrsave/msrsave.h
+
+msrsave/msrsave: msrsave/msrsave_main.o msrsave/msrsave.o
+
+msrsave/msrsave_test.o: msrsave/msrsave_test.c msrsave/msrsave.h
+
+msrsave/msrsave_test: msrsave/msrsave_test.o msrsave/msrsave.o
+
+INSTALL ?= install
+prefix ?= $(HOME)/build
+exec_prefix ?= $(prefix)
+sbindir ?= $(exec_prefix)/sbin
+datarootdir ?= $(prefix)/share
+mandir ?= $(datarootdir)/man
+man1dir ?= $(mandir)/man1
+
+install: msrsave/msrsave msrsave/msrsave.1
+	$(INSTALL) -d $(DESTDIR)/$(sbindir)
+	$(INSTALL) msrsave/msrsave $(DESTDIR)/$(sbindir)
+	$(INSTALL) -d $(DESTDIR)/$(man1dir)
+	$(INSTALL) -m 644 msrsave/msrsave.1 $(DESTDIR)/$(man1dir)
+
+.SUFFIXES: .c .o
+.PHONY: all clean install
 

--- a/msrsave/msrsave.1
+++ b/msrsave/msrsave.1
@@ -1,0 +1,83 @@
+.\" Copyright (c) 2016, Intel Corporation
+.\"
+.\" Redistribution and use in source and binary forms, with or without
+.\" modification, are permitted provided that the following conditions
+.\" are met:
+.\"
+.\"     * Redistributions of source code must retain the above copyright
+.\"       notice, this list of conditions and the following disclaimer.
+.\"
+.\"     * Redistributions in binary form must reproduce the above copyright
+.\"       notice, this list of conditions and the following disclaimer in
+.\"       the documentation and/or other materials provided with the
+.\"       distribution.
+.\"
+.\"     * Neither the name of Intel Corporation nor the names of its
+.\"       contributors may be used to endorse or promote products derived
+.\"       from this software without specific prior written permission.
+.\"
+.\" THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+.\" "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+.\" LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+.\" A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+.\" OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+.\" SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+.\" LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+.\" DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+.\" THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+.\" (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+.\" OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+.\"
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
+.
+.TH "MSRSAVE" "1" "December 2016" "" ""
+.
+.SH "NAME"
+\fBmsrsave\fR \- msr\-safe save and restore application
+.
+.SH "SYNOPSIS"
+.
+.TP
+\fBSAVE MSR:\fR
+\fBmsrsave\fR outfile
+.
+.TP
+\fBRESTORE MSR:\fR
+\fBmsrsave\fR \fB\-r\fR infile
+.
+.TP
+\fBPRINT VERSION OR HELP:\fR
+\fBmsrsave \-\-version\fR | \fB\-\-help\fR
+.
+.SH "DESCRIPTION"
+The \fBmsrsave\fR application is used to save to a file the state of
+all write accesible MSR values defined in the current MSR whitelist
+or restore the MSR values from a saved state file\. The msrsave
+application also respects the standard \fB\-\-version\fR and
+\fB\-\-help\fR options for printing the msr\-safe package version or a
+brief message about usage\.
+.
+.SH "OPTIONS"
+.
+.TP
+\fB\-\-help\fR
+.
+.br
+Print brief summary of the command line usage information, then exit\.
+.
+.TP
+\fB\-\-version\fR
+.
+.br
+Print version of msr\-safe package to standard output, then exit\.
+.
+.TP
+\fB\-r\fR
+.
+.br
+Restore the MSR values that are recorded in an existing MSR saved state
+file\.
+.
+.SH "COPYRIGHT"
+Copyright (C) 2016, Intel Corporation\. All rights reserved\.

--- a/msrsave/msrsave.c
+++ b/msrsave/msrsave.c
@@ -1,0 +1,531 @@
+/*
+ * Copyright (c) 2016, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "msrsave.h"
+
+static int msr_parse_whitelist(const char *whitelist_path, size_t *num_msr_ptr, uint64_t **msr_offset_ptr, uint64_t **msr_mask_ptr)
+{
+    enum {BUFFER_SIZE = 8192};
+    int err = 0;
+    int tmp_err = 0;
+    int i;
+    int tmp_fd = -1;
+    int whitelist_fd = -1;
+    size_t num_scan = 0;
+    size_t num_msr = 0;
+    ssize_t num_read = 0;
+    ssize_t num_write = 0;
+    char *whitelist_buffer = NULL;
+    char *whitelist_ptr = NULL;
+    uint64_t *msr_offset = NULL;
+    uint64_t *msr_mask = NULL;
+    struct stat whitelist_stat;
+    char tmp_path[NAME_MAX] = "/tmp/msrsave_whitelist_XXXXXX";
+    char err_msg[NAME_MAX];
+    char copy_buffer[BUFFER_SIZE];
+
+    /* Copy whitelist into temporary file */
+    tmp_fd = mkstemp(tmp_path);
+    if (tmp_fd == -1)
+    {
+        err = errno ? errno : -1;
+        snprintf(err_msg, NAME_MAX, "Creation of temporary file named\"%s\" failed! ", tmp_path);
+        perror(err_msg);
+        goto exit;
+    }
+
+    whitelist_fd = open(whitelist_path, O_RDONLY);
+    if (whitelist_fd == -1)
+    {
+        err = errno ? errno : -1;
+        snprintf(err_msg, NAME_MAX, "Open of whitelist file named\"%s\" failed! ", whitelist_path);
+        perror(err_msg);
+        goto exit;
+    }
+
+    while ((num_read = read(whitelist_fd, copy_buffer, sizeof(copy_buffer))))
+    {
+        if (num_read == -1)
+        {
+            err = errno ? errno : -1;
+            snprintf(err_msg, NAME_MAX, "Read of whitelist file \"%s\" failed! ", whitelist_path);
+            perror(err_msg);
+            goto exit;
+        }
+
+        num_write = write(tmp_fd, copy_buffer, num_read);
+        if (num_write != num_read)
+        {
+            err = errno ? errno : -1;
+            snprintf(err_msg, NAME_MAX, "Write to temporary file \"%s\" failed! ", tmp_path);
+            perror(err_msg);
+            goto exit;
+        }
+    }
+
+    tmp_err = close(tmp_fd);
+    tmp_fd = -1;
+    if (tmp_err == -1)
+    {
+        err = errno ? errno : -1;
+        snprintf(err_msg, NAME_MAX, "Close of temporary file named\"%s\" failed! ", tmp_path);
+        perror(err_msg);
+        goto exit;
+    }
+
+    tmp_err = close(whitelist_fd);
+    whitelist_fd = -1;
+    if (tmp_err == -1)
+    {
+        err = errno ? errno : -1;
+        snprintf(err_msg, NAME_MAX, "Close of whitelist file named\"%s\" failed! ", whitelist_path);
+        perror(err_msg);
+        goto exit;
+    }
+
+    *msr_offset_ptr = NULL;
+    *msr_mask_ptr = NULL;
+
+    /* Figure out how big the whitelist file is */
+    tmp_err = stat(tmp_path, &whitelist_stat);
+    if (tmp_err != 0)
+    {
+        err = errno ? errno : -1;
+        snprintf(err_msg, NAME_MAX, "stat() of %s failed! ", tmp_path);
+        perror(err_msg);
+        goto exit;
+    }
+
+    if (whitelist_stat.st_size == 0)
+    {
+        err = errno ? errno : -1;
+        snprintf(err_msg, NAME_MAX, "Whitelist file (%s) size is zero!", tmp_path);
+        perror(err_msg);
+        goto exit;
+    }
+
+    /* Allocate buffer for file contents */
+    whitelist_buffer = (char*)malloc(whitelist_stat.st_size);
+    if (!whitelist_buffer)
+    {
+        err = errno ? errno : -1;
+        snprintf(err_msg, NAME_MAX, "Could not allocate array of size %zu!", whitelist_stat.st_size);
+        perror(err_msg);
+        goto exit;
+    }
+
+    /* Open file */
+    tmp_fd = open(tmp_path, O_RDONLY);
+    if (tmp_fd == -1)
+    {
+        err = errno ? errno : -1;
+        snprintf(err_msg, NAME_MAX, "Could not open whitelist temporary file \"%s\"!", tmp_path);
+        perror(err_msg);
+        goto exit;
+    }
+
+    /* Read contents */
+    num_read = read(tmp_fd, whitelist_buffer, whitelist_stat.st_size);
+    if (num_read != whitelist_stat.st_size)
+    {
+        err = errno ? errno : -1;
+        snprintf(err_msg, NAME_MAX, "Contents read from whitelist file is too small: %zu < %zu!", num_read, whitelist_stat.st_size);
+        perror(err_msg);
+        goto exit;
+    }
+
+    /* close file */
+    tmp_err = close(tmp_fd);
+    tmp_fd = -1;
+    if (tmp_err)
+    {
+        err = errno ? errno : -1;
+        snprintf(err_msg, NAME_MAX, "Unable to close temporary whitelist file called \"%s\"", tmp_path);
+        perror(err_msg);
+        goto exit;
+    }
+
+    /* Count the number of new lines in the file */
+    whitelist_ptr = whitelist_buffer;
+    for (num_msr = 0; (whitelist_ptr = strchr(whitelist_ptr, '\n')); ++num_msr)
+    {
+        ++whitelist_ptr;
+    }
+    *num_msr_ptr = num_msr;
+
+    /* Allocate buffers for parsed whitelist */
+    msr_offset = *msr_offset_ptr = (uint64_t *)malloc(sizeof(uint64_t) * num_msr);
+    if (!msr_offset)
+    {
+        err = errno ? errno : -1;
+        snprintf(err_msg, NAME_MAX, "Unable to allocate msr offset data of size: %zu!", sizeof(uint64_t) * num_msr);
+        perror(err_msg);
+        goto exit;
+    }
+
+    msr_mask = *msr_mask_ptr = (uint64_t *)malloc(sizeof(uint64_t) * num_msr);
+    if (!msr_mask)
+    {
+        err = errno ? errno : -1;
+        snprintf(err_msg, NAME_MAX, "Unable to allocate msr mask data of size: %zu!", sizeof(uint64_t) * num_msr);
+        perror(err_msg);
+        goto exit;
+    }
+
+    /* Parse the whitelist */
+    const char *whitelist_format = "MSR: %llx Write Mask: %llx\n";
+    whitelist_ptr = whitelist_buffer;
+    for (i = 0; i < num_msr; ++i)
+    {
+        num_scan = sscanf(whitelist_ptr, whitelist_format, msr_offset + i, msr_mask + i);
+        if (num_scan != 2)
+        {
+            err = -1;
+            fprintf(stderr, "Error: Failed to parse whitelist file named \"%s\"\n", whitelist_path);
+            goto exit;
+        }
+        whitelist_ptr = strchr(whitelist_ptr, '\n');
+        whitelist_ptr++; /* Move the pointer to the next line */
+        if (!whitelist_ptr)
+        {
+            err = -1;
+            fprintf(stderr, "Error: Failed to parse whitelist file named \"%s\"\n", whitelist_path);
+            goto exit;
+        }
+    }
+
+exit:
+    unlink(tmp_path);
+    if (tmp_fd != -1)
+    {
+        close(tmp_fd);
+    }
+    if (whitelist_fd != -1)
+    {
+        close(whitelist_fd);
+    }
+    if (whitelist_buffer)
+    {
+        free(whitelist_buffer);
+    }
+    return err;
+}
+
+int msr_save(const char *save_path, const char *whitelist_path, const char *msr_path_format, int num_cpu)
+{
+    int err = 0;
+    int tmp_err = 0;
+    int i, j;
+    int msr_fd;
+    char err_msg[NAME_MAX];
+    size_t num_msr = 0;
+    uint64_t *msr_offset = NULL;
+    uint64_t *msr_mask = NULL;
+    uint64_t *save_buffer = NULL;
+    FILE *save_fid = NULL;
+
+    err = msr_parse_whitelist(whitelist_path, &num_msr, &msr_offset, &msr_mask);
+    if (err)
+    {
+        goto exit;
+    }
+
+    /* Allocate save buffer, a 2-D array over msr offset and then CPU
+       (offset major ordering) */
+    save_buffer = (uint64_t *)malloc(num_msr * num_cpu * sizeof(uint64_t));
+    if (!save_buffer)
+    {
+        err = errno ? errno : -1;
+        snprintf(err_msg, NAME_MAX, "Unable to allocate msr save state buffer of size: %zu!", num_msr * num_cpu * sizeof(uint64_t));
+        perror(err_msg);
+        goto exit;
+    }
+
+    /* Open all MSR files.
+     * Read ALL existing data
+     * Pass through the whitelist mask. */
+    for (i = 0; i < num_cpu; ++i)
+    {
+        char msr_file_name[NAME_MAX];
+        snprintf(msr_file_name, NAME_MAX, msr_path_format, i);
+        msr_fd = open(msr_file_name, O_RDWR);
+        if (msr_fd == -1)
+        {
+            err = errno ? errno : -1;
+            snprintf(err_msg, NAME_MAX, "Could not open MSR file \"%s\"!", msr_file_name);
+            perror(err_msg);
+            goto exit;
+        }
+        for (j = 0; j < num_msr; ++j)
+        {
+            ssize_t read_count = pread(msr_fd, save_buffer + i * num_msr + j,
+                                       sizeof(uint64_t), msr_offset[j]);
+            if (read_count != sizeof(uint64_t))
+            {
+                err = errno ? errno : -1;
+                snprintf(err_msg, NAME_MAX, "Failed to read msr value from MSR file \"%s\"!", msr_file_name);
+                perror(err_msg);
+                goto exit;
+            }
+            save_buffer[i * num_msr + j] &= msr_mask[j];
+        }
+        tmp_err = close(msr_fd);
+        msr_fd = -1;
+        if (tmp_err)
+        {
+            err = errno ? errno : -1;
+            snprintf(err_msg, NAME_MAX, "Could not close MSR file \"%s\"!", msr_file_name);
+            perror(err_msg);
+            goto exit;
+        }
+    }
+
+    /* Open output file. */
+    save_fid = fopen(save_path, "w");
+    if (!save_fid)
+    {
+        err = errno ? errno : -1;
+        snprintf(err_msg, NAME_MAX, "Could not open output file \"%s\"!", save_path);
+        perror(err_msg);
+        goto exit;
+    }
+
+    size_t num_write = fwrite(save_buffer, sizeof(uint64_t), num_msr * num_cpu, save_fid);
+    if (num_write != num_msr * num_cpu)
+    {
+        err = errno ? errno : -1;
+        snprintf(err_msg, NAME_MAX, "Could not write all values to output file \"%s\"!", save_path);
+        perror(err_msg);
+        goto exit;
+    }
+
+    tmp_err = fclose(save_fid);
+    save_fid = NULL;
+    if (tmp_err)
+    {
+        err = errno ? errno : -1;
+        snprintf(err_msg, NAME_MAX, "Could not close MSR file \"%s\"!", save_path);
+        perror(err_msg);
+        goto exit;
+    }
+
+
+    /* Clean up memory and files */
+exit:
+    if (save_buffer)
+    {
+        free(save_buffer);
+    }
+    if (msr_offset)
+    {
+        free(msr_offset);
+    }
+    if (msr_mask)
+    {
+        free(msr_mask);
+    }
+    if (save_fid)
+    {
+        fclose(save_fid);
+    }
+    if (msr_fd != -1)
+    {
+        close(msr_fd);
+    }
+    return err;
+}
+
+int msr_restore(const char *restore_path, const char *whitelist_path, const char *msr_path_format, int num_cpu)
+{
+    int err = 0;
+    int tmp_err = 0;
+    int i, j;
+    int msr_fd;
+    size_t num_msr = 0;
+    uint64_t curr_val = 0;
+    uint64_t *msr_offset = NULL;
+    uint64_t *msr_mask = NULL;
+    uint64_t *restore_buffer = NULL;
+    FILE *restore_fid = NULL;
+    struct stat restore_stat;
+    struct stat whitelist_stat;
+    char err_msg[NAME_MAX];
+
+    err = msr_parse_whitelist(whitelist_path, &num_msr, &msr_offset, &msr_mask);
+    if (err)
+    {
+        goto exit;
+    }
+
+    /* Check that the timestamp of the restore file is after the timetamp
+       for the whitelist file */
+    tmp_err = stat(restore_path, &restore_stat);
+    if (tmp_err != 0)
+    {
+        err = errno ? errno : -1;
+        snprintf(err_msg, NAME_MAX, "stat() of %s failed! ", restore_path);
+        perror(err_msg);
+        goto exit;
+    }
+
+    tmp_err = stat(whitelist_path, &whitelist_stat);
+    if (tmp_err != 0)
+    {
+        err = errno ? errno : -1;
+        snprintf(err_msg, NAME_MAX, "stat() of %s failed! ", whitelist_path);
+        perror(err_msg);
+        goto exit;
+    }
+
+    if (restore_stat.st_mtime < whitelist_stat.st_mtime)
+    {
+        err = -1;
+        fprintf(stderr, "Error: whitelist was modified after restore file was written!");
+        goto exit;
+    }
+
+    /* Allocate restore buffer, a 2-D array over msr offset and then CPU
+       (offset major ordering) */
+    restore_buffer = (uint64_t *)malloc(num_msr * num_cpu * sizeof(uint64_t));
+    if (!restore_buffer)
+    {
+        err = errno ? errno : -1;
+        snprintf(err_msg, NAME_MAX, "Unable to allocate msr restore state buffer of size: %zu!", num_msr * num_cpu * sizeof(uint64_t));
+        perror(err_msg);
+        goto exit;
+    }
+
+    restore_fid = fopen(restore_path, "r");
+    if (!restore_fid)
+    {
+        err = errno ? errno : -1;
+        snprintf(err_msg, NAME_MAX, "Could not open restore file \"%s\"!", restore_path);
+        perror(err_msg);
+        goto exit;
+    }
+
+    size_t num_read = fread(restore_buffer, sizeof(uint64_t), num_msr * num_cpu, restore_fid);
+    if (num_read != num_msr * num_cpu || fgetc(restore_fid) != EOF)
+    {
+        err = errno ? errno : -1;
+        snprintf(err_msg, NAME_MAX, "Could not write all values to output file \"%s\"!", restore_path);
+        perror(err_msg);
+        goto exit;
+    }
+
+    tmp_err = fclose(restore_fid);
+    restore_fid = NULL;
+    if (tmp_err)
+    {
+        err = errno ? errno : -1;
+        snprintf(err_msg, NAME_MAX, "Could not close MSR file \"%s\"!", restore_path);
+        perror(err_msg);
+        goto exit;
+    }
+
+    /* Open all MSR files.
+     * Read ALL existing data
+     * Pass through the whitelist mask
+     * Or in restore values
+     * Write back to MSR files. */
+    for (i = 0; i < num_cpu; ++i)
+    {
+        char msr_file_name[NAME_MAX];
+        snprintf(msr_file_name, NAME_MAX, msr_path_format, i);
+        msr_fd = open(msr_file_name, O_RDWR);
+        if (msr_fd == -1)
+        {
+            err = errno ? errno : -1;
+            snprintf(err_msg, NAME_MAX, "Could not open MSR file \"%s\"!", msr_file_name);
+            perror(err_msg);
+            goto exit;
+        }
+        for (j = 0; j < num_msr; ++j)
+        {
+            ssize_t count = pread(msr_fd, &curr_val, sizeof(uint64_t), msr_offset[j]);
+            if (count != sizeof(uint64_t))
+            {
+                err = errno ? errno : -1;
+                snprintf(err_msg, NAME_MAX, "Failed to read msr value from MSR file \"%s\"!", msr_file_name);
+                perror(err_msg);
+                goto exit;
+            }
+            curr_val &= ~(msr_mask[j]);
+            curr_val |= restore_buffer[i * num_msr + j];
+            count = pwrite(msr_fd, &curr_val, sizeof(uint64_t), msr_offset[j]);
+        }
+        tmp_err = close(msr_fd);
+        msr_fd = -1;
+        if (tmp_err)
+        {
+            err = errno ? errno : -1;
+            snprintf(err_msg, NAME_MAX, "Could not close MSR file \"%s\"!", msr_file_name);
+            perror(err_msg);
+            goto exit;
+        }
+    }
+
+    /* Clean up memory and files */
+exit:
+    if (restore_buffer)
+    {
+        free(restore_buffer);
+    }
+    if (restore_fid)
+    {
+        fclose(restore_fid);
+    }
+    if (msr_offset)
+    {
+        free(msr_offset);
+    }
+    if (msr_mask)
+    {
+        free(msr_mask);
+    }
+    if (msr_fd != -1)
+    {
+        close(msr_fd);
+    }
+    return err;
+}

--- a/msrsave/msrsave.h
+++ b/msrsave/msrsave.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2015, 2016, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef MSRSAVE_H_INCLUDE
+#define MSRSAVE_H_INCLUDE
+
+int msr_save(const char *out_path,
+             const char *whitelist_path,
+             const char *msr_path,
+             int num_cpu);
+
+int msr_restore(const char *in_path,
+                const char *whitelist_path,
+                const char *msr_path,
+                int num_cpu);
+
+#endif

--- a/msrsave/msrsave_main.c
+++ b/msrsave/msrsave_main.c
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2016, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+#include <getopt.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "msrsave.h"
+
+#ifndef VERSION
+#define VERSION "0.0.0"
+#endif
+
+int main(int argc, char **argv)
+{
+    const char *usage =
+"NAME\n"
+"       msrsave - msr-safe save and restore application\n"
+"\n"
+"SYNOPSIS\n"
+"       SAVE MSR:\n"
+"              msrsave outfile\n"
+"\n"
+"       RESTORE MSR:\n"
+"              msrsave -r infile\n"
+"\n"
+"       PRINT VERSION OR HELP:\n"
+"              msrsave --version | --help\n"
+"\n"
+"DESCRIPTION\n"
+"       The  msrsave  application  is  used  to save to a file the  state of all write\n"
+"       accessible MSR values defined in the current MSR whitelist or restore the MSR\n"
+"       values from a saved state file. The msrsave application  also respects the\n"
+"       standard --version  and  --help  options  for  printing  the msr-safe pack-\n"
+"       age version or a brief message about usage.\n"
+"\n"
+"OPTIONS\n"
+"       --help\n"
+"              Print brief summary of the command line usage information, then exit.\n"
+"\n"
+"       --version\n"
+"              Print version of msr-safe package to standard output, then exit.\n"
+"\n"
+"       -r\n"
+"              Restore the MSR values that are recorded in an existing MSR saved state\n"
+"              file.\n"
+"\n"
+"COPYRIGHT\n"
+"       Copyright (C) 2016, Intel Corporation. All rights reserved.\n"
+"\n"
+"\n";
+
+    if (argc > 1 &&
+        strncmp(argv[1], "--version", strlen("--version") + 1) == 0)
+    {
+        printf("%s\n", VERSION);
+        printf("\nCopyright (C) 2016, Intel Corporation. All rights reserved.\n\n");
+        return 0;
+    }
+    if (argc > 1 && (
+        strncmp(argv[1], "--help", strlen("--help") + 1) == 0 ||
+        strncmp(argv[1], "-h", strlen("-h") + 1) == 0))
+    {
+        printf(usage, argv[0]);
+        return 0;
+    }
+
+    int err = 0;
+    int do_restore = 0;
+    int opt = 0;
+
+    while (!err && (opt = getopt(argc, argv, "r")) != -1)
+    {
+        switch (opt)
+        {
+            case 'r':
+                do_restore = 1;
+                break;
+            default:
+                fprintf(stderr, "Error: Unknown parameter \"%c\"\n\n", opt);
+                fprintf(stderr, usage, argv[0]);
+                err = EINVAL;
+                break;
+        }
+    }
+
+    if (!err && optind == argc)
+    {
+        fprintf(stderr, "Error: No file name specified.\n\n", argv[0]);
+        fprintf(stderr, usage, argv[0]);
+        err = EINVAL;
+    }
+
+    if (!err)
+    {
+        const char *file_name = argv[optind];
+        const char *msr_path = "/dev/cpu/%d/msr_safe";
+        const char *msr_whitelist_path = "/dev/cpu/msr_whitelist";
+        int num_cpu = sysconf(_SC_NPROCESSORS_ONLN);
+        if (do_restore)
+        {
+            err = msr_restore(file_name, msr_whitelist_path, msr_path, num_cpu);
+        }
+        else
+        {
+            err = msr_save(file_name, msr_whitelist_path, msr_path, num_cpu);
+        }
+    }
+
+    return err;
+}
+

--- a/msrsave/msrsave_test.c
+++ b/msrsave/msrsave_test.c
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2016, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <assert.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "msrsave.h"
+
+void msrsave_test_mock_msr(void *buffer, size_t buffer_size, const char *path_format, int num_cpu);
+void msrsave_test_check_msr(uint64_t *buffer, size_t num_check, const char *path_format, int num_cpu);
+
+void msrsave_test_mock_msr(void *buffer, size_t buffer_size, const char *path_format, int num_cpu)
+{
+    /* Create mock msr files for each CPU */
+    int i;
+    char this_path[NAME_MAX] = {};
+    for (i = 0; i < num_cpu; ++i)
+    {
+        snprintf(this_path, NAME_MAX, path_format, i);
+        FILE *fid = fopen(this_path, "w");
+        assert(fid != 0);
+        fwrite(buffer, 1, buffer_size, fid);
+        fclose(fid);
+    }
+}
+
+void msrsave_test_check_msr(uint64_t *check_val, size_t num_check, const char *path_format, int num_cpu)
+{
+    /* Create mock msr files for each CPU */
+    int i, j;
+    char this_path[NAME_MAX] = {};
+    uint64_t *read_val = malloc(num_check * sizeof(uint64_t));
+    assert(read_val != NULL);
+    for (i = 0; i < num_cpu; ++i)
+    {
+        snprintf(this_path, NAME_MAX, path_format, i);
+        FILE *fid = fopen(this_path, "r");
+        assert(fid != 0);
+        fread(read_val, sizeof(uint64_t), num_check, fid);
+        fclose(fid);
+        for (j = 0; j < num_check; ++j)
+        {
+            assert(check_val[j] == read_val[j]);
+        }
+    }
+    free(read_val);
+}
+
+
+int main(int argc, char **argv)
+{
+    int err = 0;
+    const uint64_t whitelist_off[] = {0x0000000000000000ULL,
+                                      0x0000000000000008ULL,
+                                      0x0000000000000010ULL,
+                                      0x0000000000000018ULL,
+                                      0x0000000000000020ULL,
+                                      0x0000000000000028ULL,
+                                      0x0000000000000030ULL,
+                                      0x0000000000000038ULL,
+                                      0x0000000000000040ULL,
+                                      0x0000000000000048ULL,
+                                      0x0000000000000050ULL,
+                                      0x0000000000000058ULL,
+                                      0x0000000000000060ULL,
+                                      0x0000000000000068ULL,
+                                      0x0000000000000070ULL,
+                                      0x0000000000000078ULL,
+                                      0x0000000000000080ULL,
+                                      0x0000000000000088ULL,
+                                      0x0000000000000090ULL,
+                                      0x0000000000000098ULL};
+
+    const uint64_t whitelist_mask[] = {0x8000000000000000ULL,
+                                       0x8000000000000000ULL,
+                                       0x8000000000000000ULL,
+                                       0x8000000000000000ULL,
+                                       0x8000000000000000ULL,
+                                       0x8000000000000000ULL,
+                                       0x8000000000000000ULL,
+                                       0x8000000000000000ULL,
+                                       0x8000000000000000ULL,
+                                       0x8000000000000000ULL,
+                                       0x8000000000000000ULL,
+                                       0x8000000000000000ULL,
+                                       0x8000000000000000ULL,
+                                       0x8000000000000000ULL,
+                                       0x8000000000000000ULL,
+                                       0x8000000000000000ULL,
+                                       0x8000000000000000ULL,
+                                       0x8000000000000000ULL,
+                                       0x8000000000000000ULL,
+                                       0x8000000000000000ULL};
+
+    enum {NUM_MSR = sizeof(whitelist_off) / sizeof(uint64_t)};
+    assert(NUM_MSR == sizeof(whitelist_mask) / sizeof(uint64_t));
+    const char *test_save_path = "msrsave_test_store";
+    const char *test_whitelist_path = "msrsave_test_whitelist";
+    const char *test_msr_path = "msrsave_test_msr.%d";
+    const char *whitelist_format = "MSR: %.8llx Write Mask: %.16llx\n";
+    const int num_cpu = 10;
+    int i;
+
+    /* Create a mock white list from the data in the constants above. */
+    FILE *fid = fopen(test_whitelist_path, "w");
+    assert(fid != NULL);
+    for (i = 0; i < NUM_MSR; ++i)
+    {
+        fprintf(fid, whitelist_format, whitelist_off[i], whitelist_mask[i]);
+    }
+    fclose(fid);
+
+    uint64_t lval = 0x0;
+    uint64_t hval = 0xDEADBEEF;
+    uint64_t msr_val[NUM_MSR];
+
+    /* Create mock msr data */
+    for (i = 0; i < NUM_MSR; ++i)
+    {
+        lval = i;
+        msr_val[i] = lval | (hval << 32);
+    }
+
+    msrsave_test_mock_msr(msr_val, sizeof(msr_val), test_msr_path, num_cpu);
+
+    /* Save the current state to a file */
+    err = msr_save(test_save_path, test_whitelist_path, test_msr_path, num_cpu);
+    assert(err == 0);
+
+    /* Overwrite the mock msr files with new data */
+    hval = 0x1EADBEEF;
+    for (i = 0; i < NUM_MSR; ++i)
+    {
+        lval = NUM_MSR - i;
+        msr_val[i] = lval | (hval << 32);
+    }
+
+    msrsave_test_mock_msr(msr_val, sizeof(msr_val), test_msr_path, num_cpu);
+
+    /* Restore to the original values */
+    err = msr_restore(test_save_path, test_whitelist_path, test_msr_path, num_cpu);
+    assert(err == 0);
+
+    /* Check that the values that are writable have been restored. */
+    /* Check that the values that are not writable have been unaltered. */
+    hval = 0x9EADBEEF;
+    for (i = 0; i < NUM_MSR; ++i)
+    {
+        lval = NUM_MSR - i;
+        msr_val[i] = lval | (hval << 32);
+    }
+    msrsave_test_check_msr(msr_val, sizeof(msr_val) / sizeof(uint64_t), test_msr_path, num_cpu);
+
+    char this_path[NAME_MAX] = {};
+    for (i = 0; i < num_cpu; ++i)
+    {
+        snprintf(this_path, NAME_MAX, test_msr_path, i);
+        unlink(this_path);
+    }
+    unlink(test_whitelist_path);
+    unlink(test_save_path);
+    return err;
+}

--- a/rpm/msr-safe.spec
+++ b/rpm/msr-safe.spec
@@ -28,10 +28,12 @@ for flavor in %flavors_to_build; do
     rm -rf obj/$flavor
     mkdir -p obj/$flavor
     cp -r msr* Makefile obj/$flavor
-    make -C %{kernel_source $flavor} M=$PWD/obj/$flavor
+    %{__make} -C %{kernel_source $flavor} M=$PWD/obj/$flavor
 done
+%{__make} CPPFLAGS="-DVERSION=\\\"%{version}-%{release}\\\"" msrsave/msrsave
 
 %install
+%{__make} install DESTDIR=%{buildroot} prefix=%{_prefix} sbindir=%{_sbindir} mandir=%{_mandir}
 install -d %{buildroot}/%{_datadir}/msr-safe/whitelists
 install -m 0644 whitelists/* %{buildroot}/%{_datadir}/msr-safe/whitelists/
 install -d %{buildroot}%{_unitdir}
@@ -80,8 +82,14 @@ fi
 %{_udevrulesdir}/10-msr-safe.rules
 %config %{_sysconfdir}/sysconfig/msr-safe
 %doc README
+%{_sbindir}/msrsave
+%dir %{_mandir}/man1
+%doc %{_mandir}/man1/msrsave.1.gz
+
 
 %changelog
+* Mon Dec 05 2016 Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>
+- Add msrsave application build and install.
 * Wed Apr 20 2016 Ben Allen <bsallen@alcf.anl.gov> 7667118-1
 - Initial release (v7667118)
 


### PR DESCRIPTION
- Old implementation relyed on stat of sysfs file to determine the size
  of the output buffer when read.

Signed-off-by: Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>