### PR TITLE
Use inode_lock and inode_unlock in supported kernel versions, mutex_l…

### DIFF
--- a/msr_entry.c
+++ b/msr_entry.c
@@ -58,7 +58,11 @@ static loff_t msr_seek(struct file *file, loff_t offset, int orig)
 	loff_t ret;
 	struct inode *inode = file->f_mapping->host;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,5,0)
+	inode_lock(inode);
+#else
 	mutex_lock(&inode->i_mutex);
+#endif
 	switch (orig) {
 	case SEEK_SET:
 		file->f_pos = offset;
@@ -71,7 +75,11 @@ static loff_t msr_seek(struct file *file, loff_t offset, int orig)
 	default:
 		ret = -EINVAL;
 	}
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,5,0)
+	inode_unlock(inode);
+#else
 	mutex_unlock(&inode->i_mutex);
+#endif
 	return ret;
 }
 


### PR DESCRIPTION
…ock and mutex_unlock not available in current versions

This PR fixes #11 and supersedes PRs #12 and #21.  #12 would work fine, but we might as well use the abstractions that `inode_lock` and `inode_unlock` provide in `linux/fs.h` since v4.5 (thanks @maiterth for finding these functions).  #21's git history diverged after a rebase on master, and doesn't appear to be implemented correctly anyway.