### PR TITLE
Add After=network.target to systemd Unit

### DIFF
--- a/rpm/msr-safe.service
+++ b/rpm/msr-safe.service
@@ -6,7 +6,7 @@
 
 [Unit]
 Description=Sets default MSR whitelist
-After=nss-user-lookup.target nslcd.service
+After=nss-user-lookup.target nslcd.service network.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Start msr-safe after network.target has been reached in an attempt start after any units that commonly load kernel modules. msr-safe appears to dynamically pick its devices' MAJOR number. If kernel modules with hard coded MAJOR numbers are loaded after msr-safe there is a good chance for conflict. Causing the later loaded kernel module to fail to load.

Work around for #45.