### PR TITLE
Fix RPM build and service startup

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,1 @@
+README.md

--- a/rpm/msr-safe.sh
+++ b/rpm/msr-safe.sh
@@ -7,8 +7,8 @@ set -o pipefail
 
 wl_cpu() {
   printf 'wl_%.2x%x\n' \
-  $( tr -d "\t " < /proc/cpuinfo | grep -m1 'cpufamily:' | cut -f2 -d:) \
-  $( tr -d "\t " < /proc/cpuinfo | grep -m1 'model:' | cut -f2 -d:)
+  $(grep -m1 'cpu family' /proc/cpuinfo | cut -f2 -d: | tr -d ' ') \
+  $(grep -m1 'model' /proc/cpuinfo | cut -f2 -d: | tr -d ' ')
 }
 
 start() {


### PR DESCRIPTION
Without the first patch, build_rpm.sh is broken.

The second patch fixes an error with the ```tr``` command that's used to parse the family and model number of the CPU.

Without the second patch, examining the service status on CentOS and RHEL shows the following:
```
$ sudo service msr-safe status
Redirecting to /bin/systemctl status msr-safe.service
● msr-safe.service - Sets default MSR whitelist
   Loaded: loaded (/usr/lib/systemd/system/msr-safe.service; enabled; vendor preset: disabled)
   Active: active (exited) since Mon 2019-10-14 17:09:11 PDT; 2 weeks 3 days ago
  Process: 8191 ExecStart=/usr/sbin/msr-safe start (code=exited, status=0/SUCCESS)
 Main PID: 8191 (code=exited, status=0/SUCCESS)
    Tasks: 0
   Memory: 0B
   CGroup: /system.slice/msr-safe.service

Oct 14 17:09:11 mcfly16 systemd[1]: Starting Sets default MSR whitelist...
Oct 14 17:09:11 mcfly16 msr-safe[8191]: tr: write error: Broken pipe
Oct 14 17:09:11 mcfly16 msr-safe[8191]: tr: write error
Oct 14 17:09:11 mcfly16 msr-safe[8191]: tr: write error: Broken pipe
Oct 14 17:09:11 mcfly16 msr-safe[8191]: tr: write error
Oct 14 17:09:11 mcfly16 systemd[1]: Started Sets default MSR whitelist.
```

With the second patch in place:
```
$ sudo service msr-safe status
[sudo] password for bgeltz:
Redirecting to /bin/systemctl status msr-safe.service
● msr-safe.service - Sets default MSR whitelist
   Loaded: loaded (/usr/lib/systemd/system/msr-safe.service; enabled; vendor preset: disabled)
   Active: active (exited) since Fri 2019-11-01 14:38:53 PDT; 4min 36s ago
  Process: 98111 ExecStop=/usr/sbin/msr-safe stop (code=exited, status=0/SUCCESS)
  Process: 98142 ExecStart=/usr/sbin/msr-safe start (code=exited, status=0/SUCCESS)
 Main PID: 98142 (code=exited, status=0/SUCCESS)

Nov 01 14:38:53 mcfly15 systemd[1]: Starting Sets default MSR whitelist...
Nov 01 14:38:53 mcfly15 systemd[1]: Started Sets default MSR whitelist.
```