### PR TITLE
update docs on setting msrsave version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,12 +48,17 @@ clean:
 check: msrsave/msrsave_test
 	msrsave/msrsave_test
 
+# current msr-safe/msrsave version
+CURRENT_VERSION := -DVERSION=\"1.4.0\"
+
 msrsave/msrsave.o: msrsave/msrsave.c msrsave/msrsave.h
-	$(CC) $(CFLAGS) -fPIC -shared -c msrsave/msrsave.c -o $@
+	$(CC) $(CFLAGS) $(CURRENT_VERSION) -fPIC -shared -c msrsave/msrsave.c -o $@
 
 msrsave/msrsave_main.o: msrsave/msrsave_main.c msrsave/msrsave.h
+	$(CC) $(CFLAGS) $(CURRENT_VERSION) -fPIC -shared -c msrsave/msrsave_main.c -o $@
 
 msrsave/msrsave: msrsave/msrsave_main.o msrsave/msrsave.o
+	$(CC) $(CFLAGS) $(CURRENT_VERSION) $^ -o $@
 
 msrsave/msrsave_test.o: msrsave/msrsave_test.c msrsave/msrsave.h
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ the SLURM resource manager as a SPANK plugin. This plugin can be built with the
 uses the SLURM SPANK infrastructure to make a popen(3) call to the msrsave
 command line utility in the job epilogue and prologue.
 
+The version of msrsave (and msr-safe) can be modified by updating the following
+compiler flag:
+
+    -DVERSION=\"MAJOR.MINOR.PATCH\"
+
+The msrsave version can be queried with:
+
+    msrsave --version
+
 Troubleshooting
 ---------------
 


### PR DESCRIPTION
Sync msrsave and msr-safe version. Update the current version by changing the `CURRENT_VERSION` variable in the Makefile.

Resolves #73.