### PR TITLE
Fixes stack size warning.

### DIFF
--- a/msr-smp.c
+++ b/msr-smp.c
@@ -90,7 +90,7 @@ int msr_safe_batch(struct msr_batch_array *oa)
     cpumask_var_t cpus_to_run_on;
     struct msr_batch_op *op;
 
-    zalloc_cpumask_var( &cpus_to_run_on, GFP_KERNEL );
+    zalloc_cpumask_var(&cpus_to_run_on, GFP_KERNEL);
 
     for (op = oa->ops; op < oa->ops + oa->numops; ++op)
     {


### PR DESCRIPTION
The struct cpuset can be unusually large; putting it on the stack
generates a compile-time warning.  This commit uses
CONFIG_CPUMASK_OFFSTACK to determine if we can allocate struct
cpuset at runtime.  If that constant is not defined, we fall back
to the original warning-generating behavior.

I'm not sure this is a great solution, but ideally this struct
will not have to be allocated often and the performance impact
should only be in the initial latency before batch measurements.

Fixes #82 