### PR TITLE
Service bug fix and spec version enhancement

### DIFF
--- a/rpm/msr-safe.sh
+++ b/rpm/msr-safe.sh
@@ -20,7 +20,7 @@ start() {
     ALLOWLIST="/usr/share/msr-safe/allowlists/${AL_CPU}"
   fi
 
-  if [ -f "/usr/share/msr-safe/allowlists/${AL_CPU}" ]; then
+  if [ -f "${ALLOWLIST}" ]; then
     /sbin/modprobe msr-safe && \
     cat "${ALLOWLIST}" > /dev/cpu/msr_allowlist
 

--- a/rpm/msr-safe.spec
+++ b/rpm/msr-safe.spec
@@ -1,9 +1,10 @@
+%global tag         %(git describe --tags --abbrev=0 | sed -e "s|^v||")
 %global rev         %(git rev-parse HEAD)
 %global shortrev    %(r=%{rev}; echo ${r:0:12})
 
 Name:       msr-safe
-Version:    0
-Release:    0.4.git%{shortrev}%{?dist}
+Version:    %{tag}.git%{shortrev}%{?dist}
+Release:    1
 License:    GPLv2
 Summary:    Allows safer access to model specific registers (MSRs)
 Url:        https://github.com/LLNL/msr-safe


### PR DESCRIPTION
Fixes a longstanding bug where the service would not modprobe msr-safe or setup /dev/cpu/allowlist if the ALLOWLIST sysconfig override was used but there was *not* a default allowlist that matched AL_CPU.

Enhances the spec file to use the most recent tag as the basis for the version string.