### PR TITLE
Removes ioctl() interface from msr_entry.

### DIFF
--- a/msr_entry.c
+++ b/msr_entry.c
@@ -184,70 +184,6 @@ static ssize_t msr_write(struct file *file, const char __user *buf, size_t count
     return bytes ? bytes : err;
 }
 
-static long msr_ioctl(struct file *file, unsigned int ioc, unsigned long arg)
-{
-    u32 __user *uregs = (u32 __user *)arg;
-    u32 regs[8];
-    int cpu = iminor(file->f_path.dentry->d_inode);
-    int err = 0;
-
-    if (!capable(CAP_SYS_RAWIO))
-    {
-        return -EACCES;
-    }
-
-    switch (ioc)
-    {
-        case X86_IOC_RDMSR_REGS:
-            if (!(file->f_mode & FMODE_READ))
-            {
-                err = -EBADF;
-                break;
-            }
-            if (copy_from_user(&regs, uregs, sizeof(regs)))
-            {
-                err = -EFAULT;
-                break;
-            }
-            err = rdmsr_safe_regs_on_cpu(cpu, regs);
-            if (err)
-            {
-                break;
-            }
-            if (copy_to_user(uregs, &regs, sizeof(regs)))
-            {
-                err = -EFAULT;
-            }
-            break;
-        case X86_IOC_WRMSR_REGS:
-            if (!(file->f_mode & FMODE_WRITE))
-            {
-                err = -EBADF;
-                break;
-            }
-            if (copy_from_user(&regs, uregs, sizeof(regs)))
-            {
-                err = -EFAULT;
-                break;
-            }
-            err = wrmsr_safe_regs_on_cpu(cpu, regs);
-            if (err)
-            {
-                break;
-            }
-            if (copy_to_user(uregs, &regs, sizeof(regs)))
-            {
-                err = -EFAULT;
-            }
-            break;
-        default:
-            err = -ENOTTY;
-            break;
-    }
-
-    return err;
-}
-
 static int msr_open(struct inode *inode, struct file *file)
 {
     unsigned int cpu = iminor(file->f_path.dentry->d_inode);
@@ -280,8 +216,6 @@ static const struct file_operations msr_fops =
     .read = msr_read,
     .write = msr_write,
     .open = msr_open,
-    .unlocked_ioctl = msr_ioctl,
-    .compat_ioctl = msr_ioctl,
     .release = msr_close
 };
 


### PR DESCRIPTION
This interface was a holdover from when we were thinking of msr-safe as a replacement for the stock msr kernel module. Current use has msr_safe existing alongside msr, so no need to duplicate its functionality.

Fixes #95 