### PR TITLE
Removes loops from read and write interfaces.

### DIFF
--- a/msr_entry.c
+++ b/msr_entry.c
@@ -97,11 +97,10 @@ static ssize_t msr_read(struct file *file, char __user *buf, size_t count, loff_
     u32 reg = *ppos;
     int cpu = iminor(file->f_path.dentry->d_inode);
     int err = 0;
-    ssize_t bytes = 0;
 
-    if (count % 8)
+    if (count != 8)
     {
-        return -EINVAL; /* Invalid chunk size */
+        return -EINVAL; /* Single read only.*/
     }
 
     if (!capable(CAP_SYS_RAWIO) && !msr_allowlist_maskexists(reg))
@@ -109,23 +108,18 @@ static ssize_t msr_read(struct file *file, char __user *buf, size_t count, loff_
         return -EACCES;
     }
 
-    for (; count; count -= 8)
+    err = rdmsr_safe_on_cpu(cpu, reg, &data[0], &data[1]);
+    if (err)
     {
-        err = rdmsr_safe_on_cpu(cpu, reg, &data[0], &data[1]);
-        if (err)
-        {
-            break;
-        }
-        if (copy_to_user(tmp, &data, 8))
-        {
-            err = -EFAULT;
-            break;
-        }
-        tmp += 2;
-        bytes += 8;
+        return err;
     }
 
-    return bytes ? bytes : err;
+    if (copy_to_user(tmp, &data, 8))
+    {
+        return -EFAULT;
+    }
+
+    return 8;
 }
 
 static ssize_t msr_write(struct file *file, const char __user *buf, size_t count, loff_t *ppos)
@@ -137,11 +131,10 @@ static ssize_t msr_write(struct file *file, const char __user *buf, size_t count
     u64 mask;
     int cpu = iminor(file->f_path.dentry->d_inode);
     int err = 0;
-    ssize_t bytes = 0;
 
-    if (count % 8)
+    if (count != 8) /* single write only */
     {
-        return -EINVAL; // Invalid chunk size
+        return -EINVAL; 
     }
 
     mask = capable(CAP_SYS_RAWIO) ? 0xffffffffffffffff : msr_allowlist_writemask(reg);
@@ -151,37 +144,31 @@ static ssize_t msr_write(struct file *file, const char __user *buf, size_t count
         return -EACCES;
     }
 
-    for (; count; count -= 8)
+    if (copy_from_user(&data, tmp, 8))
     {
-        if (copy_from_user(&data, tmp, 8))
-        {
-            err = -EFAULT;
-            break;
-        }
-
-        if (mask != 0xffffffffffffffff)
-        {
-            err = rdmsr_safe_on_cpu(cpu, reg, &curdata[0], &curdata[1]);
-            if (err)
-            {
-                break;
-            }
-
-            *(u64 *)&curdata[0] &= ~mask;
-            *(u64 *)&data[0] &= mask;
-            *(u64 *)&data[0] |= *(u64 *)&curdata[0];
-        }
-
-        err = wrmsr_safe_on_cpu(cpu, reg, data[0], data[1]);
-        if (err)
-        {
-            break;
-        }
-        tmp += 2;
-        bytes += 8;
+        return -EFAULT;
     }
 
-    return bytes ? bytes : err;
+    if (mask != 0xffffffffffffffff)
+    {
+        err = rdmsr_safe_on_cpu(cpu, reg, &curdata[0], &curdata[1]);
+        if (err)
+        {
+            return err;
+        }
+
+        *(u64 *)&curdata[0] &= ~mask;
+        *(u64 *)&data[0] &= mask;
+        *(u64 *)&data[0] |= *(u64 *)&curdata[0];
+    }
+
+    err = wrmsr_safe_on_cpu(cpu, reg, data[0], data[1]);
+    if (err)
+    {
+        return err;
+    }
+
+    return 8;
 }
 
 static long msr_ioctl(struct file *file, unsigned int ioc, unsigned long arg)


### PR DESCRIPTION
These date back to the original msr kernel module.  The read loop allowed a single msr to be polled repeatedly.  The write loop wrote to a single msr multiple times.  The msr_safe batch interface provides a more flexible approach.

Calling pread/pwrite/read/write on /dev/cpu/*/msr_safe now requires a buffer size of 8 bytes and will return 8 on success.

Fixes #96 