### PR TITLE
Removes CAP_SYS_RAWIO checks.

### DIFF
--- a/msr_batch.c
+++ b/msr_batch.c
@@ -69,7 +69,6 @@ static int msrbatch_apply_allowlist(struct msr_batch_array *oa)
 {
     struct msr_batch_op *op;
     int err = 0;
-    bool has_sys_rawio_cap = capable(CAP_SYS_RAWIO);
 
     for (op = oa->ops; op < oa->ops + oa->numops; ++op)
     {
@@ -79,12 +78,6 @@ static int msrbatch_apply_allowlist(struct msr_batch_array *oa)
         {
             pr_debug("No such CPU %d\n", op->cpu);
             op->err = err = -ENXIO; // No such CPU
-            continue;
-        }
-
-        if (has_sys_rawio_cap)
-        {
-            op->wmask = 0xffffffffffffffff;
             continue;
         }
 

--- a/msr_entry.c
+++ b/msr_entry.c
@@ -104,7 +104,7 @@ static ssize_t msr_read(struct file *file, char __user *buf, size_t count, loff_
         return -EINVAL; /* Invalid chunk size */
     }
 
-    if (!capable(CAP_SYS_RAWIO) && !msr_allowlist_maskexists(reg))
+    if (!msr_allowlist_maskexists(reg))
     {
         return -EACCES;
     }
@@ -144,9 +144,9 @@ static ssize_t msr_write(struct file *file, const char __user *buf, size_t count
         return -EINVAL; // Invalid chunk size
     }
 
-    mask = capable(CAP_SYS_RAWIO) ? 0xffffffffffffffff : msr_allowlist_writemask(reg);
+    mask = msr_allowlist_writemask(reg);
 
-    if (!capable(CAP_SYS_RAWIO) && mask == 0)
+    if (mask == 0)
     {
         return -EACCES;
     }


### PR DESCRIPTION
CAP_SYS_RAWIO checks are another holdover from backwards compatibility with the stock msr kernel module.  Absent that rationale, allowing "someone who isn't quite root"[1] to have unfettered access to all MSRs doens't make a lot of sense when there is a much finer-grained access control method available.

[1] https://lwn.net/Articles/542327/

Fixes #102 

Requires #99 (which removes the check in the ioctl interface)