### PR TITLE
Adds /dev/cpu/msr_safe_version device.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 #CFLAGS_msr-smp.o := -DDEBUG
 
 obj-m += msr-safe.o
-msr-safe-objs := msr_entry.o msr_allowlist.o msr-smp.o msr_batch.o
+msr-safe-objs := msr_entry.o msr_allowlist.o msr-smp.o msr_batch.o msr_version.o
 
 all: msrsave/msrsave
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules

--- a/msr_version.c
+++ b/msr_version.c
@@ -10,6 +10,7 @@
 #include <linux/fs.h>
 #include <linux/version.h>
 #include <linux/module.h>
+#include <linux/uaccess.h>
 
 static struct class *cdev_class;
 static char cdev_created;

--- a/msr_version.c
+++ b/msr_version.c
@@ -27,13 +27,16 @@ static ssize_t read_version(struct file *file, char __user *buf, size_t count, l
     size_t len = strlen( THIS_MODULE->version ) + 1 < count ?
         strlen( THIS_MODULE->version ) + 1 :
         count;
-    if(*ppos > 0){
+    if (*ppos > 0)
+    {
         return 0;
     }
-    if(len > count){
+    if (len > count)
+    {
         return -EFAULT;
     }
-    if(copy_to_user( buf, THIS_MODULE->version, len)){
+    if (copy_to_user(buf, THIS_MODULE->version, len))
+    {
         return -EFAULT;
     }
     *ppos = 1;

--- a/msr_version.c
+++ b/msr_version.c
@@ -1,0 +1,118 @@
+// Copyright 2011-2021 Lawrence Livermore National Security, LLC and other
+// msr-safe Project Developers. See the top-level COPYRIGHT file for
+// details.
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
+
+#include <linux/device.h>
+#include <linux/fs.h>
+#include <linux/version.h>
+#include <linux/module.h>
+
+static struct class *cdev_class;
+static char cdev_created;
+static char cdev_registered;
+static char cdev_class_created;
+
+static int open_version(struct inode *inode, struct file *file)
+{
+    return 0;
+}
+
+static ssize_t read_version(struct file *file, char __user *buf, size_t count, loff_t *ppos)
+{
+    size_t len = strlen( THIS_MODULE->version ) + 1 < count ?
+        strlen( THIS_MODULE->version ) + 1 :
+        count;
+    if(*ppos > 0){
+        return 0;
+    }
+    if(len > count){
+        return -EFAULT;
+    }
+    if(copy_to_user( buf, THIS_MODULE->version, len)){
+        return -EFAULT;
+    }
+    *ppos = 1;
+    return len;
+}
+
+static const struct file_operations fops =
+{
+    .owner = THIS_MODULE,
+    .read = read_version,
+    .open = open_version
+};
+
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,39)
+static char *msr_version_nodename(struct device *dev, mode_t *mode)
+#else
+static char *msr_version_nodename(struct device *dev, umode_t *mode)
+#endif
+{
+    return kasprintf(GFP_KERNEL, "cpu/msr_safe_version");
+}
+
+void msr_version_cleanup(int majordev)
+{
+    if (cdev_created)
+    {
+        cdev_created = 0;
+        device_destroy(cdev_class, MKDEV(majordev, 0));
+    }
+
+    if (cdev_class_created)
+    {
+        cdev_class_created = 0;
+        class_destroy(cdev_class);
+    }
+
+    if (cdev_registered)
+    {
+        cdev_registered = 0;
+        unregister_chrdev(majordev, "cpu/msr_safe_version");
+    }
+}
+
+int msr_version_init(int *majordev)
+{
+    int err = 0;
+    struct device *dev;
+
+    err = register_chrdev(*majordev, "cpu/msr_safe_version", &fops);
+    if (err < 0)
+    {
+        pr_debug("%s: unable to register chrdev\n", __FUNCTION__);
+        msr_version_cleanup(*majordev);
+        err = -EBUSY;
+        return err;
+    }
+    if (err > 0)
+    {
+        *majordev = err;
+    }
+    cdev_registered = 1;
+
+    cdev_class = class_create(THIS_MODULE, "msr_safe_version");
+    if (IS_ERR(cdev_class))
+    {
+        err = PTR_ERR(cdev_class);
+        msr_version_cleanup(*majordev);
+        return err;
+    }
+    cdev_class_created = 1;
+
+    cdev_class->devnode = msr_version_nodename;
+
+    dev = device_create(cdev_class, NULL, MKDEV(*majordev, 0), NULL, "msr_safe_version");
+    if (IS_ERR(dev))
+    {
+        err = PTR_ERR(dev);
+        msr_version_cleanup(*majordev);
+        return err;
+    }
+    cdev_created = 1;
+    return 0;
+}

--- a/msr_version.h
+++ b/msr_version.h
@@ -1,0 +1,25 @@
+// Copyright 2011-2021 Lawrence Livermore National Security, LLC and other
+// msr-safe Project Developers. See the top-level COPYRIGHT file for
+// details.
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Internal declarations for x86 MSR version implementation functions.
+ *
+ * Thank you to everyone who has contributed and helped with this project:
+ *
+ * Kathleen Shoga, Peter Bailey, Trent D'Hooge, Jim Foraker, David Lowenthal
+ * Tapasya Patki, Barry Rountree, Kendrick Shaw, Marty McFadden
+ */
+
+#ifndef _ARCH_X68_KERNEL_MSR_VERSION_HEADER_INCLUDE
+#define _ARCH_X68_KERNEL_MSR_VERSION_HEADER_INCLUDE
+
+#include <linux/types.h>
+
+int msr_version_init(int *majordev);
+
+int msr_version_cleanup(int majordev);
+
+#endif


### PR DESCRIPTION
Catting (or just reading) the file prints out the version of the loaded msr-safe kernel module.

It's a lot of code to just get a version number, but I suspect many users will not otherwise have access to that information, short of emailing the sysadmin who installed the module.  A lighter-weight alternative would have been to put the information into an ioctl() call, but that would require writing code just to figure out the version number.

Fixes #79 