### PR TITLE
Disambiguates multiple error states.

### DIFF
--- a/msr_allowlist.c
+++ b/msr_allowlist.c
@@ -106,7 +106,7 @@ static ssize_t write_allowlist(struct file *file, const char __user *buf, size_t
     if (count+1 > MAX_WLIST_BSIZE)
     {
         pr_err("%s: buffer of %zu bytes too large\n", __FUNCTION__, count);
-        return -EINVAL;
+        return -E2BIG;
     }
 
     kbuf = kzalloc(count+1, GFP_KERNEL);
@@ -143,7 +143,7 @@ static ssize_t write_allowlist(struct file *file, const char __user *buf, size_t
     if (num_entries == 0)
     {
         pr_err("%s: No valid entries found in %zu bytes of input\n", __FUNCTION__, count);
-        err = -EINVAL;
+        err = -ENOMSG;
         goto out_freebuffer;
     }
 
@@ -173,7 +173,7 @@ static ssize_t write_allowlist(struct file *file, const char __user *buf, size_t
             if (find_in_allowlist(entry->msr))
             {
                 pr_err("%s: Duplicate: %llX\n", __FUNCTION__, entry->msr);
-                err = -EINVAL;
+                err = -ENOTUNIQ;
                 delete_allowlist();
                 goto out_releasemutex;
             }
@@ -220,7 +220,7 @@ static ssize_t read_allowlist(struct file *file, char __user *buf, size_t count,
 
     if (len > count)
     {
-        return -EFAULT;
+        return -E2BIG;
     }
 
     if (copy_to_user(tmp, kbuf, len))
@@ -336,7 +336,7 @@ static int parse_next_allowlist_entry(char *inbuf, char **nextinbuf, struct allo
         if (*s == 0)
         {
             pr_debug("%s: Premature EOF\n", __FUNCTION__);
-            return -EINVAL;
+            return -EILSEQ;
         }
 
         tmp = *s;

--- a/msr_batch.c
+++ b/msr_batch.c
@@ -100,7 +100,7 @@ static int msrbatch_apply_allowlist(struct msr_batch_array *oa)
             if (op->wmask == 0 && !op->isrdmsr)
             {
                 pr_debug("MSR %x is read-only\n", op->msr);
-                op->err = err = -EACCES;
+                op->err = err = -EROFS;
             }
         }
     }
@@ -147,7 +147,7 @@ static long msrbatch_ioctl(struct file *f, unsigned int ioc, unsigned long arg)
     koa.ops = kmalloc_array(koa.numops, sizeof(*koa.ops), GFP_KERNEL);
     if (!koa.ops)
     {
-        return -ENOMEM;
+        return -E2BIG;
     }
 
     if (copy_from_user(koa.ops, uops, koa.numops * sizeof(*koa.ops)))


### PR DESCRIPTION
Previously, a userspace-visible return code could indicate one of several possible error states.  For example, calling write(2) on the allowlist device might return EINVAL for four different errors.

This PR disambiguates those error states with unique return values.

msr_allowlist.c:write_allowlist()

        When the allowlist is too large for the buffer, return
        -E2BIG instead of -EINVAL.

        When no valid entries are found in the allowlist, return
        -ENOMSG instead of -EINVAL.

        When a duplicate entry is found in the allowlist, return
        -ENOTUNIQ instead of -EINVAL.

        -EINVAL retained for parsing errors.

msr_allowlist.c:read_allowlist()

        When the allowlist is too large for the buffer, return
        -E2BIG instead of -EINVAL.

        -EFAULT retained for copy_to_user() failure.

msr_allowlist.c:parse_next_allowlist_entry()

        When there is a premature EOF, return
        -EILSEQ instead of -EINVAL.

        -EINVAL retained for parsing errors.

msr_batch.c:msrbatch_apply_allowlist()

        When attempting to write a read-only MSR, return
        -EROFS instead of -EACCESS.

        -EACCESS retained for attempting to read or write and
        MSR that is not in the allowlist.

msr_batch.c:msrbatch_batch_ioctl()

        When the array of operations is too large, return
        -E2BIG instead of -ENOMEM.

        -ENOMEM retained for zalloc failure.

Fixes #112 