### PR TITLE
Removes open and close fileops from msr_batch.

### DIFF
--- a/msr_batch.c
+++ b/msr_batch.c
@@ -38,33 +38,6 @@ static char cdev_created;
 static char cdev_registered;
 static char cdev_class_created;
 
-static int msrbatch_open(struct inode *inode, struct file *file)
-{
-    unsigned int cpu;
-    struct cpuinfo_x86 *c;
-
-    cpu = iminor(file->f_path.dentry->d_inode);
-    if (cpu >= nr_cpu_ids || !cpu_online(cpu))
-    {
-        pr_debug("cpu #%u does not exist\n", cpu);
-        return -ENXIO; // No such CPU
-    }
-
-    c = &cpu_data(cpu);
-    if (!cpu_has(c, X86_FEATURE_MSR))
-    {
-        pr_debug("cpu #%u does not have MSR feature.\n", cpu);
-        return -EIO; // MSR not supported
-    }
-
-    return 0;
-}
-
-static int msrbatch_close(struct inode *inode, struct file *file)
-{
-    return 0;
-}
-
 static int msrbatch_apply_allowlist(struct msr_batch_array *oa)
 {
     struct msr_batch_op *op;
@@ -189,10 +162,8 @@ bundle_alloc:
 static const struct file_operations fops =
 {
     .owner = THIS_MODULE,
-    .open = msrbatch_open,
     .unlocked_ioctl = msrbatch_ioctl,
-    .compat_ioctl = msrbatch_ioctl,
-    .release = msrbatch_close
+    .compat_ioctl = msrbatch_ioctl
 };
 
 void msrbatch_cleanup(int majordev)


### PR DESCRIPTION
This was copy/paste code from the msr_safe device that's not useful for the batch device.

The `X86_FEATURE_MSR` is only used in two places in the kernel source:  msr.c and `arch/x86/include/asm/required-features.h`.  The latter states 

```
Define minimum CPUID feature set for kernel These bits are checked
   really early to actually display a visible error message before the
   kernel dies.
```

No need to be checking it here (or in msr-entry, for that matter).

Fixes #118 #117 