### PR TITLE
Removes X86_FEATURE_MSR check.

### DIFF
--- a/msr_entry.c
+++ b/msr_entry.c
@@ -185,12 +185,6 @@ static int msr_open(struct inode *inode, struct file *file)
         return -ENXIO;  // No such CPU
     }
 
-    c = &cpu_data(cpu);
-    if (!cpu_has(c, X86_FEATURE_MSR))
-    {
-        return -EIO; // MSR not supported
-    }
-
     return 0;
 }
 


### PR DESCRIPTION
The only other place the feature check is used is during boot. I can imagine a worlds where a subset of cores do not have MSR capabilities.  If that CPU architecture ever becomes reality we can add it back in.  Until then, no need to check for this.

Fixes #122 