### PR TITLE
Rountree/fix warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,10 @@ check: msrsave/msrsave_test
 CURRENT_VERSION := -DVERSION=\"1.6.0\"
 
 msrsave/msrsave.o: msrsave/msrsave.c msrsave/msrsave.h
-	$(CC) $(CFLAGS) $(CURRENT_VERSION) -fPIC -shared -c msrsave/msrsave.c -o $@
+	$(CC) $(CFLAGS) $(CURRENT_VERSION) -fPIC -c msrsave/msrsave.c -o $@
 
 msrsave/msrsave_main.o: msrsave/msrsave_main.c msrsave/msrsave.h
-	$(CC) $(CFLAGS) $(CURRENT_VERSION) -fPIC -shared -c msrsave/msrsave_main.c -o $@
+	$(CC) $(CFLAGS) $(CURRENT_VERSION) -fPIC -c msrsave/msrsave_main.c -o $@
 
 msrsave/msrsave: msrsave/msrsave_main.o msrsave/msrsave.o
 	$(CC) $(CFLAGS) $(CURRENT_VERSION) $^ -o $@

--- a/msr_entry.c
+++ b/msr_entry.c
@@ -178,7 +178,6 @@ static ssize_t msr_write(struct file *file, const char __user *buf, size_t count
 static int msr_open(struct inode *inode, struct file *file)
 {
     unsigned int cpu = iminor(file->f_path.dentry->d_inode);
-    struct cpuinfo_x86 *c;
 
     if (cpu >= nr_cpu_ids || !cpu_online(cpu))
     {


### PR DESCRIPTION
Fixes two warnings:  one for an unused variable, one for an unused flag in the msrsave target.

Fixes #134 