### PR TITLE
Fix build with added Linux Kernel Version and RHEL check for RHEL backported change.

### DIFF
--- a/msr_batch.c
+++ b/msr_batch.c
@@ -180,13 +180,23 @@ void msrbatch_cleanup(int majordev)
     }
 }
 
+// Check the Linux Kernel version to determine whether to use
+// a const struct or a struct for device.
 #if LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,39)
 static char *msrbatch_nodename(struct device *dev, mode_t *mode)
 #else
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,18,0)
+static char *msrbatch_nodename(struct device *dev, umode_t *mode)
+#else
 #if LINUX_VERSION_CODE <= KERNEL_VERSION(6,2,0)
+#ifndef RHEL_RELEASE
 static char *msrbatch_nodename(struct device *dev, umode_t *mode)
 #else
 static char *msrbatch_nodename(const struct device *dev, umode_t *mode)
+#endif
+#else
+static char *msrbatch_nodename(const struct device *dev, umode_t *mode)
+#endif
 #endif
 #endif
 {
@@ -224,6 +234,8 @@ int msrbatch_init(int *majordev)
     }
     cdev_class_created = 1;
 
+    // Depending on the Linux Kernel version and backports, this may fail with an incompatible
+    // pointer error. If so, you may need to modify above where msrbatch_nodename is declared.
     cdev_class->devnode = msrbatch_nodename;
 
     dev = device_create(cdev_class, NULL, MKDEV(*majordev, 0), NULL, "msr_batch");

--- a/msr_version.c
+++ b/msr_version.c
@@ -50,13 +50,23 @@ static const struct file_operations fops =
     .open = open_version
 };
 
+// Check the Linux Kernel version to determine whether to use
+// a const struct or a struct for device.
 #if LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,39)
 static char *msr_version_nodename(struct device *dev, mode_t *mode)
 #else
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,18,0)
+static char *msr_version_nodename(struct device *dev, umode_t *mode)
+#else
 #if LINUX_VERSION_CODE <= KERNEL_VERSION(6,2,0)
+#ifndef RHEL_RELEASE
 static char *msr_version_nodename(struct device *dev, umode_t *mode)
 #else
 static char *msr_version_nodename(const struct device *dev, umode_t *mode)
+#endif
+#else
+static char *msr_version_nodename(const struct device *dev, umode_t *mode)
+#endif
 #endif
 #endif
 {
@@ -120,6 +130,8 @@ int msr_version_init(int *majordev)
     }
     cdev_class_created = 1;
 
+    // Depending on the Linux Kernel version and backports, this may fail with an incompatible
+    // pointer error. If so, you may need to modify above where msr_version_nodename is declared.
     cdev_class->devnode = msr_version_nodename;
 
     dev = device_create(cdev_class, NULL, MKDEV(*majordev, 0), NULL, "msr_safe_version");


### PR DESCRIPTION
Fix build with added Linux Kernel Version and RHEL check for RHEL backported change.

Requires const struct device *dev rather than struct device *dev for devnode.