### PR TITLE
Update the boot script to the new allowlist naming

### DIFF
--- a/rpm/msr-safe.sh
+++ b/rpm/msr-safe.sh
@@ -6,7 +6,7 @@ set -o pipefail
 . /etc/sysconfig/msr-safe
 
 al_cpu() {
-  printf 'al_%.2x%x\n' \
+  printf 'al_%.2X_%X\n' \
   $(grep -m1 'cpu family' /proc/cpuinfo | cut -f2 -d: | tr -d ' ') \
   $(grep -m1 'model' /proc/cpuinfo | cut -f2 -d: | tr -d ' ')
 }


### PR DESCRIPTION
With the patch:

```
# bash -x /usr/sbin/msr-safe start
+ set -o nounset
+ set -o pipefail
+ . /etc/sysconfig/msr-safe
+ rc=0
+ case "${1:-}" in
+ start
+ '[' -z '' ']'
++ al_cpu
+++ grep -m1 'cpu family' /proc/cpuinfo
+++ cut -f2 -d:
+++ tr -d ' '
+++ grep -m1 model /proc/cpuinfo
+++ cut -f2 -d:
+++ tr -d ' '
++ printf 'al_%.2X_%X\n' 6 143
+ AL_CPU=al_06_8F
+ '[' -z '' ']'
+ ALLOWLIST=/usr/share/msr-safe/allowlists/al_06_8F
+ '[' -f /usr/share/msr-safe/allowlists/al_06_8F ']'
+ /sbin/modprobe msr-safe
+ cat /usr/share/msr-safe/allowlists/al_06_8F
+ return 0
+ rc=0
+ exit 0
```