### PR TITLE
Fixes several missing-prototype warnings.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ prefix ?= $(HOME)/build
 exec_prefix ?= $(prefix)
 sbindir ?= $(exec_prefix)/sbin
 libdir ?= $(exec_preffix)/lib
-datarootdir ?= $(prefix)/shae
+datarootdir ?= $(prefix)/share
 mandir ?= $(datarootdir)/man
 man1dir ?= $(mandir)/man1
 

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ prefix ?= $(HOME)/build
 exec_prefix ?= $(prefix)
 sbindir ?= $(exec_prefix)/sbin
 libdir ?= $(exec_preffix)/lib
-datarootdir ?= $(prefix)/share
+datarootdir ?= $(prefix)/shae
 mandir ?= $(datarootdir)/man
 man1dir ?= $(mandir)/man1
 
@@ -69,6 +69,22 @@ install: msrsave/msrsave msrsave/msrsave.1
 install-spank: spank
 	$(INSTALL) -d $(DESTDIR)/$(libdir)/slurm
 	$(INSTALL) msrsave/libspank_msrsafe.so $(DESTDIR)/$(libdir)/slurm/libspank_msrsafe.so
+
+# The current spack package ignore this Makefile for building the
+# msr-safe.ko kernel module, as it is building against an arbitrary
+# version of the linux kernel and thus $(shell uname -r) is not useful.
+#
+# Installation relies on the spack package setting DESTDIR to the
+# msr-safe package prefix spec variable.
+#
+# Later iterations of the spack package might also build and install
+# msrsave.  That will likely require a reworking of this Makefile.
+# Prefer single-source-of-truth in that case.
+spack-install:
+	$(INSTALL) -d $(DESTDIR)/lib/modules
+	$(INSTALL) msr-safe.ko $(DESTDIR)/lib/modules
+	$(INSTALL) -d $(DESTDIR)/include
+	$(INSTALL) msr_safe.h $(DESTDIR)/include
 
 .SUFFIXES: .c .o
 .PHONY: all clean install spank install-spank

--- a/msr-smp.c
+++ b/msr-smp.c
@@ -18,6 +18,7 @@
 #include <linux/smp.h>
 
 #include "msr_safe.h"
+#include "msr-smp.h"
 
 static void __msr_safe_batch(void *info)
 {

--- a/msr-smp.h
+++ b/msr-smp.h
@@ -1,3 +1,9 @@
+// Copyright 2011-2021 Lawrence Livermore National Security, LLC and other
+// msr-safe Project Developers. See the top-level COPYRIGHT file for
+// details.
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 #ifndef MSR_SMP_INCLUDE
 #define MSR_SMP_INCLUDE
 

--- a/msr-smp.h
+++ b/msr-smp.h
@@ -1,5 +1,6 @@
 #ifndef MSR_SMP_INCLUDE
 #define MSR_SMP_INCLUDE
-int msr_safe_batch(struct msr_batch_array *oa);
-#endif
 
+int msr_safe_batch(struct msr_batch_array *oa);
+
+#endif

--- a/msr-smp.h
+++ b/msr-smp.h
@@ -1,0 +1,5 @@
+#ifndef MSR_SMP_INCLUDE
+#define MSR_SMP_INCLUDE
+int msr_safe_batch(struct msr_batch_array *oa);
+#endif
+

--- a/msr_allowlist.c
+++ b/msr_allowlist.c
@@ -15,6 +15,7 @@
 #include <linux/slab.h>
 #include <linux/uaccess.h>
 #include <linux/version.h>
+#include "msr_allowlist.h"
 
 #define MAX_WLIST_BSIZE ((128 * 1024) + 1) // "+1" for null character
 

--- a/msr_allowlist.c
+++ b/msr_allowlist.c
@@ -15,6 +15,7 @@
 #include <linux/slab.h>
 #include <linux/uaccess.h>
 #include <linux/version.h>
+
 #include "msr_allowlist.h"
 
 #define MAX_WLIST_BSIZE ((128 * 1024) + 1) // "+1" for null character

--- a/msr_allowlist.h
+++ b/msr_allowlist.h
@@ -20,7 +20,7 @@
 
 int msr_allowlist_init(int *majordev);
 
-int msr_allowlist_cleanup(int majordev);
+void msr_allowlist_cleanup(int majordev);
 
 int msr_allowlist_exists(void);
 

--- a/msr_batch.c
+++ b/msr_batch.c
@@ -31,6 +31,7 @@
 
 #include "msr_batch.h"
 #include "msr_safe.h"
+#include "msr-smp.h"
 #include "msr_allowlist.h"
 
 static struct class *cdev_class;
@@ -73,7 +74,6 @@ static int msrbatch_apply_allowlist(struct msr_batch_array *oa)
     return err;
 }
 
-extern int msr_safe_batch(struct msr_batch_array *oa);
 
 static long msrbatch_ioctl(struct file *f, unsigned int ioc, unsigned long arg)
 {

--- a/msr_batch.c
+++ b/msr_batch.c
@@ -74,7 +74,6 @@ static int msrbatch_apply_allowlist(struct msr_batch_array *oa)
     return err;
 }
 
-
 static long msrbatch_ioctl(struct file *f, unsigned int ioc, unsigned long arg)
 {
     int err = 0;

--- a/msr_entry.c
+++ b/msr_entry.c
@@ -44,7 +44,6 @@
 #include "msr_batch.h"
 #include "msr_allowlist.h"
 #include "msr_version.h"
-#include "msr_version.h"
 
 static struct class *msr_class;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0)

--- a/msr_entry.c
+++ b/msr_entry.c
@@ -44,6 +44,7 @@
 #include "msr_batch.h"
 #include "msr_allowlist.h"
 #include "msr_version.h"
+#include "msr_version.h"
 
 static struct class *msr_class;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0)

--- a/msr_version.c
+++ b/msr_version.c
@@ -11,6 +11,7 @@
 #include <linux/version.h>
 #include <linux/module.h>
 #include <linux/uaccess.h>
+#include "msr_version.h"
 
 static struct class *cdev_class;
 static char cdev_created;

--- a/msr_version.c
+++ b/msr_version.c
@@ -11,6 +11,7 @@
 #include <linux/version.h>
 #include <linux/module.h>
 #include <linux/uaccess.h>
+
 #include "msr_version.h"
 
 static struct class *cdev_class;

--- a/msr_version.h
+++ b/msr_version.h
@@ -20,6 +20,6 @@
 
 int msr_version_init(int *majordev);
 
-int msr_version_cleanup(int majordev);
+void msr_version_cleanup(int majordev);
 
 #endif


### PR DESCRIPTION
Compiling under Linux 6.9.9 and gcc 10.3.1.

Fixes #164 