### PR TITLE
Single source of truth for version information.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ msrsave/msrsave_main.o: msrsave/msrsave_main.c msrsave/msrsave.h
 	$(CC) $(CFLAGS) -fPIC -c msrsave/msrsave_main.c -o $@
 
 msrsave/msrsave: msrsave/msrsave_main.o msrsave/msrsave.o
-	$(CC) $(CFLAGS)  $^ -o $@
+	$(CC) $(CFLAGS) $^ -o $@
 
 msrsave/msrsave_test.o: msrsave/msrsave_test.c msrsave/msrsave.h
 

--- a/Makefile
+++ b/Makefile
@@ -25,17 +25,14 @@ clean:
 check: msrsave/msrsave_test
 	msrsave/msrsave_test
 
-# current msr-safe/msrsave version
-CURRENT_VERSION := -DVERSION=\"1.7.0\"
-
 msrsave/msrsave.o: msrsave/msrsave.c msrsave/msrsave.h
-	$(CC) $(CFLAGS) $(CURRENT_VERSION) -fPIC -c msrsave/msrsave.c -o $@
+	$(CC) $(CFLAGS) -fPIC -c msrsave/msrsave.c -o $@
 
 msrsave/msrsave_main.o: msrsave/msrsave_main.c msrsave/msrsave.h
-	$(CC) $(CFLAGS) $(CURRENT_VERSION) -fPIC -c msrsave/msrsave_main.c -o $@
+	$(CC) $(CFLAGS) -fPIC -c msrsave/msrsave_main.c -o $@
 
 msrsave/msrsave: msrsave/msrsave_main.o msrsave/msrsave.o
-	$(CC) $(CFLAGS) $(CURRENT_VERSION) $^ -o $@
+	$(CC) $(CFLAGS)  $^ -o $@
 
 msrsave/msrsave_test.o: msrsave/msrsave_test.c msrsave/msrsave.h
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ being a pointer to a __struct msr_batch_array__.
 struct msr_batch_array
 {
     __u32 numops;             // In: # of operations in operations array
-    __u32 version;	      // In: MSR_SAFE_VERSION_u32 (see msr_version.h)
+    __u32 version;            // In: MSR_SAFE_VERSION_u32 (see msr_version.h)
     struct msr_batch_op *ops; // In: Array[numops] of operations
 };
 ```

--- a/README.md
+++ b/README.md
@@ -135,12 +135,19 @@ being a pointer to a __struct msr_batch_array__.
 struct msr_batch_array
 {
     __u32 numops;             // In: # of operations in operations array
+    __u32 version;	      // In: MSR_SAFE_VERSION_u32 (see msr_version.h)
     struct msr_batch_op *ops; // In: Array[numops] of operations
 };
 ```
 
 The maximum __numops__ is system-dependent, but 30k operations is not
-unheard-of.  Each op is contained in a __struct msr_batch_op__:
+unheard-of.
+
+Starting in version 2.0.0, the __version__ field will be
+compared to the version of the loaded kernel module with a mismatch
+resulting in an error.  Earlier versions do not check this field.
+
+Each op is contained in a __struct msr_batch_op__:
 
 ```
 struct msr_batch_op

--- a/msr_entry.c
+++ b/msr_entry.c
@@ -396,5 +396,5 @@ module_exit(msr_exit)
 
 MODULE_AUTHOR("M. Fadden, K. Shoga, B. Rountree, H. P. Anvin");
 MODULE_DESCRIPTION("x86 generic MSR driver (+LLNL Approved List)");
-MODULE_VERSION( MSR_SAFE_VERSION_STR );
+MODULE_VERSION(MSR_SAFE_VERSION_STR);
 MODULE_LICENSE("GPL");

--- a/msr_entry.c
+++ b/msr_entry.c
@@ -396,5 +396,5 @@ module_exit(msr_exit)
 
 MODULE_AUTHOR("M. Fadden, K. Shoga, B. Rountree, H. P. Anvin");
 MODULE_DESCRIPTION("x86 generic MSR driver (+LLNL Approved List)");
-MODULE_VERSION("1.7");
+MODULE_VERSION( MSR_SAFE_VERSION_STR );
 MODULE_LICENSE("GPL");

--- a/msr_safe.h
+++ b/msr_safe.h
@@ -31,6 +31,7 @@ struct msr_batch_op
 struct msr_batch_array
 {
     __u32 numops;             // In: # of operations in operations array
+    __u32 version;	      // In: MSR_SAFE_VERSION_u32 (see msr_version.h)
     struct msr_batch_op *ops; // In: Array[numops] of operations
 };
 

--- a/msr_version.h
+++ b/msr_version.h
@@ -22,4 +22,26 @@ int msr_version_init(int *majordev);
 
 int msr_version_cleanup(int majordev);
 
+#define MSR_SAFE_VERSION_MAJOR 1
+#define MSR_SAFE_VERSION_MINOR 8
+#define MSR_SAFE_VERSION_PATCH 0
+
+#define MSR_SAFE_VERSION_u32 ( \
+	          ( MSR_SAFE_VERSION_MAJOR << 16 )	\
+		| ( MSR_SAFE_VERSION_MINOR << 8 )	\
+		| ( MSR_SAFE_VERSION_PATCH << 0 ) )
+
+#define MAKESTRING( s ) #s
+#define MAKE_VERSION_STRING(major,minor,patch) \
+	MAKESTRING( major ) 	\
+	"."			\
+	MAKESTRING( minor )	\
+	"."			\
+	MAKESTRING( patch )
+
+#define MSR_SAFE_VERSION_STR MAKE_VERSION_STRING(\
+		MSR_SAFE_VERSION_MAJOR,\
+		MSR_SAFE_VERSION_MINOR,\
+		MSR_SAFE_VERSION_PATCH)
+
 #endif

--- a/msr_version.h
+++ b/msr_version.h
@@ -27,21 +27,21 @@ int msr_version_cleanup(int majordev);
 #define MSR_SAFE_VERSION_PATCH 0
 
 #define MSR_SAFE_VERSION_u32 ( \
-	          ( MSR_SAFE_VERSION_MAJOR << 16 )	\
-		| ( MSR_SAFE_VERSION_MINOR << 8 )	\
-		| ( MSR_SAFE_VERSION_PATCH << 0 ) )
+    ( MSR_SAFE_VERSION_MAJOR << 16 )	\
+    | ( MSR_SAFE_VERSION_MINOR << 8 )	\
+	| ( MSR_SAFE_VERSION_PATCH << 0 ) )
 
 #define MAKESTRING( s ) #s
 #define MAKE_VERSION_STRING(major,minor,patch) \
-	MAKESTRING( major ) 	\
-	"."			\
-	MAKESTRING( minor )	\
-	"."			\
-	MAKESTRING( patch )
+    MAKESTRING( major ) 	\
+    "."			\
+    MAKESTRING( minor )	\
+    "."			\
+    MAKESTRING( patch )
 
 #define MSR_SAFE_VERSION_STR MAKE_VERSION_STRING(\
-		MSR_SAFE_VERSION_MAJOR,\
-		MSR_SAFE_VERSION_MINOR,\
-		MSR_SAFE_VERSION_PATCH)
+    MSR_SAFE_VERSION_MAJOR,\
+    MSR_SAFE_VERSION_MINOR,\
+    MSR_SAFE_VERSION_PATCH)
 
 #endif

--- a/msrsave/msrsave_main.c
+++ b/msrsave/msrsave_main.c
@@ -14,10 +14,7 @@
 #include <unistd.h>
 
 #include "msrsave.h"
-
-#ifndef VERSION
-#define VERSION "0.0.0"
-#endif
+#include "../msr_version.h"
 
 int main(int argc, char **argv)
 {
@@ -59,7 +56,7 @@ int main(int argc, char **argv)
 
     if (argc > 1 && strncmp(argv[1], "--version", strlen("--version") + 1) == 0)
     {
-        printf("%s\n", VERSION);
+        printf("%s\n", MSR_SAFE_VERSION_STR);
         printf("\nCopyright (C) 2016, Intel Corporation. All rights reserved.\n\n");
         return 0;
     }


### PR DESCRIPTION
Fixes #167 

msr_version.h
	#defines for major, minor, and patch versions of msr-safe
	as well as helper macros to generate _u32 and string
	representation.

Makefile
	Removes CURRENT_VERSION and -DVERSION from build.
	msrsave now gets the version string from msr_version.h

msrsave_main.c
msr_entry.c
	Now #includes msr_version.h and uses MSR_SAFE_VERSION_STR

msr_safe.h
	Repurposes a bit of struct padding to hold a _u32-format
	msr-safe version number.

README.md
	Updates documentation of struct msr_batch_array to note
	the new version field.  Explains how this will remain
	unused in the 1.x.y series.  Version 2.x.y will begin
	checking this version field to make sure what the user
	compiled against is the same version as the loaded
	kernel module.  This is necessary due to anticipated
	batch API changes in version 2.0.0.

Tested on serif (Ubuntu 24.04.1 LTS, Linux 6.8.0, gcc 13.2.0)