### PR TITLE
Version checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ prefix ?= $(HOME)/build
 exec_prefix ?= $(prefix)
 sbindir ?= $(exec_prefix)/sbin
 libdir ?= $(exec_preffix)/lib
-datarootdir ?= $(prefix)/shae
+datarootdir ?= $(prefix)/share
 mandir ?= $(datarootdir)/man
 man1dir ?= $(mandir)/man1
 

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ prefix ?= $(HOME)/build
 exec_prefix ?= $(prefix)
 sbindir ?= $(exec_prefix)/sbin
 libdir ?= $(exec_preffix)/lib
-datarootdir ?= $(prefix)/share
+datarootdir ?= $(prefix)/shae
 mandir ?= $(datarootdir)/man
 man1dir ?= $(mandir)/man1
 
@@ -69,6 +69,22 @@ install: msrsave/msrsave msrsave/msrsave.1
 install-spank: spank
 	$(INSTALL) -d $(DESTDIR)/$(libdir)/slurm
 	$(INSTALL) msrsave/libspank_msrsafe.so $(DESTDIR)/$(libdir)/slurm/libspank_msrsafe.so
+
+# The current spack package ignore this Makefile for building the
+# msr-safe.ko kernel module, as it is building against an arbitrary
+# version of the linux kernel and thus $(shell uname -r) is not useful.
+#
+# Installation relies on the spack package setting DESTDIR to the
+# msr-safe package prefix spec variable.
+#
+# Later iterations of the spack package might also build and install
+# msrsave.  That will likely require a reworking of this Makefile.
+# Prefer single-source-of-truth in that case.
+spack-install:
+	$(INSTALL) -d $(DESTDIR)/lib/modules
+	$(INSTALL) msr-safe.ko $(DESTDIR)/lib/modules
+	$(INSTALL) -d $(DESTDIR)/include
+	$(INSTALL) msr_safe.h $(DESTDIR)/include
 
 .SUFFIXES: .c .o
 .PHONY: all clean install spank install-spank

--- a/Makefile
+++ b/Makefile
@@ -25,17 +25,14 @@ clean:
 check: msrsave/msrsave_test
 	msrsave/msrsave_test
 
-# current msr-safe/msrsave version
-CURRENT_VERSION := -DVERSION=\"1.7.0\"
-
 msrsave/msrsave.o: msrsave/msrsave.c msrsave/msrsave.h
-	$(CC) $(CFLAGS) $(CURRENT_VERSION) -fPIC -c msrsave/msrsave.c -o $@
+	$(CC) $(CFLAGS) -fPIC -c msrsave/msrsave.c -o $@
 
 msrsave/msrsave_main.o: msrsave/msrsave_main.c msrsave/msrsave.h
-	$(CC) $(CFLAGS) $(CURRENT_VERSION) -fPIC -c msrsave/msrsave_main.c -o $@
+	$(CC) $(CFLAGS) -fPIC -c msrsave/msrsave_main.c -o $@
 
 msrsave/msrsave: msrsave/msrsave_main.o msrsave/msrsave.o
-	$(CC) $(CFLAGS) $(CURRENT_VERSION) $^ -o $@
+	$(CC) $(CFLAGS)  $^ -o $@
 
 msrsave/msrsave_test.o: msrsave/msrsave_test.c msrsave/msrsave.h
 

--- a/README.md
+++ b/README.md
@@ -135,12 +135,19 @@ being a pointer to a __struct msr_batch_array__.
 struct msr_batch_array
 {
     __u32 numops;             // In: # of operations in operations array
+    __u32 version;	      // In: MSR_SAFE_VERSION_u32 (see msr_version.h)
     struct msr_batch_op *ops; // In: Array[numops] of operations
 };
 ```
 
 The maximum __numops__ is system-dependent, but 30k operations is not
-unheard-of.  Each op is contained in a __struct msr_batch_op__:
+unheard-of.
+
+Starting in version 2.0.0, the __version__ field will be
+compared to the version of the loaded kernel module with a mismatch
+resulting in an error.  Earlier versions do not check this field.
+
+Each op is contained in a __struct msr_batch_op__:
 
 ```
 struct msr_batch_op

--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ unheard-of.
 
 Starting in version 2.0.0, the __version__ field will be
 compared to the version of the loaded kernel module with a mismatch
-resulting in an error.  Earlier versions do not check this field.
+in the major version number resulting in an error.
+Earlier versions do not check this field.
 
 Each op is contained in a __struct msr_batch_op__:
 
@@ -292,17 +293,11 @@ Requested virtual CPU does not exist or is offline.
 ### /dev/cpu/msr_batch
 
 ### **ioctl(2)**
+Verifying the batch request can result in the following errors.
 
-All of the operations in the batch will be executed.  Each operation may result
-in an __EIO__, __ENXIO__, __EACCES__, or __EROFS__ error, which will be
-recorded in the __msr_batch_op__ struct.  If any operation caused an error, the
-first such error becomes the return value for **ioctl(2)**.
-
-__E2BIG__
-Kernel unable to allocate memory to hold the array of operations.
-
-__EACCES__
-An individual operation requested an MSR that is not present in the allowlist.
+__ENOTTY__
+Invalid ioctl command.  As of this writing the only ioctl command
+supported on this device is __X86_IOC_MSR_BATCH__, defined in __msr_safe.h__.
 
 __EBADF__
 The __msr_batch__ file was not opened for reading.
@@ -311,7 +306,25 @@ __EFAULT__
 Kernel **copy_from_user()** or **copy_to_user()** failed.
 
 __EINVAL__
-Number of requested batch operations is <=0.
+Number of requested batch operations is 0.
+
+__ENOPROTOOPT__
+There is a mismatch between the major version number of the currently-loaded
+msr-safe kernel module and the version number requested by the batch struct.
+
+__E2BIG__
+Kernel unable to allocate memory to hold the array of operations.
+
+__ENOMEM__
+Kernel unable to allocate memory to hold the results of __zalloc_cpumask_var()__.
+
+If all is well, all of the operations in the batch will be executed.  If an
+individual operation results in one of the following errors, the error will
+be recorded in its __msr_batch_op__ struct.  The first of these errors will
+become the return value for **ioctl(2)**.
+
+__EACCES__
+An individual operation requested an MSR that is not present in the allowlist.
 
 __EIO__
 A general protection fault occurred.  On Intel processors this
@@ -319,13 +332,6 @@ can be caused by a) attempting to access an MSR outside of ring 0, b)
 attempting to access a non-existent or reserved MSR address, c) writing 1-bits
 to a reserved area of an MSR, d) writing a non-canonical address to MSRs that
 take memory addresses, or e) writing to MSR bits that are marked as read-only.
-
-__ENOMEM__
-Kernel unable to allocate memory to hold the results of __zalloc_cpumask_var()__.
-
-__ENOTTY__
-Invalid ioctl command.  As of this writing the only ioctl command
-supported on this device is __X86_IOC_MSR_BATCH__, defined in __msr_safe.h__.
 
 __ENXIO__
 An individual operation requested a virtual CPU does not exist or is offline.

--- a/examples/example.c
+++ b/examples/example.c
@@ -26,13 +26,14 @@
 #include <stdlib.h>     // exit(3)
 #include <sys/ioctl.h>  // ioctl(2)
 
-#include "../msr_safe.h"   // batch data structs
+#include "../msr_safe.h"   	// batch data structs
+#include "../msr_version.h"	// MSR_SAFE_VERSION_u32
 
 #define MSR_MPERF 0xE7
 
 char const *const allowlist = "0xE7 0xFFFFFFFFFFFFFFFF\n";  // MPERF
 
-static uint8_t const nCPUs = 32;
+static uint8_t const nCPUs = 16;
 
 void set_allowlist()
 {
@@ -74,7 +75,7 @@ void measure_serial_latency()
 
     // Show results
     printf("Serial cycles from first write to last read:"
-           "%"PRIu64" (on %"PRIu8" CPUs)\n",
+           "%9"PRIu64" (on %"PRIu8" CPUs)\n",
            data[nCPUs - 1], nCPUs);
 }
 
@@ -95,7 +96,8 @@ void measure_batch_latency()
         r_ops[i].msr = w_ops[i].msr = MSR_MPERF;
         w_ops[i].msrdata = 0;
     }
-    rbatch.numops = wbatch.numops = nCPUs;
+    rbatch.numops  = wbatch.numops  = nCPUs;
+    rbatch.version = wbatch.version = MSR_SAFE_VERSION_u32;
     rbatch.ops = r_ops;
     wbatch.ops = w_ops;
 
@@ -104,8 +106,8 @@ void measure_batch_latency()
     rc = ioctl(fd, X86_IOC_MSR_BATCH, &rbatch);
     assert(-1 != rc);
 
-    printf("Batch cycles from first write to last read:"
-           "%llu (on %"PRIu8" CPUs)\n",
+    printf("Batch cycles from first write to last read: "
+           "%9llu (on %"PRIu8" CPUs)\n",
            r_ops[nCPUs - 1].msrdata, nCPUs);
 }
 

--- a/msr-smp.c
+++ b/msr-smp.c
@@ -18,6 +18,7 @@
 #include <linux/smp.h>
 
 #include "msr_safe.h"
+#include "msr-smp.h"
 
 static void __msr_safe_batch(void *info)
 {

--- a/msr-smp.h
+++ b/msr-smp.h
@@ -1,0 +1,5 @@
+#ifndef MSR_SMP_INCLUDE
+#define MSR_SMP_INCLUDE
+int msr_safe_batch(struct msr_batch_array *oa);
+#endif
+

--- a/msr_allowlist.c
+++ b/msr_allowlist.c
@@ -15,6 +15,7 @@
 #include <linux/slab.h>
 #include <linux/uaccess.h>
 #include <linux/version.h>
+#include "msr_allowlist.h"
 
 #define MAX_WLIST_BSIZE ((128 * 1024) + 1) // "+1" for null character
 

--- a/msr_allowlist.h
+++ b/msr_allowlist.h
@@ -20,7 +20,7 @@
 
 int msr_allowlist_init(int *majordev);
 
-int msr_allowlist_cleanup(int majordev);
+void msr_allowlist_cleanup(int majordev);
 
 int msr_allowlist_exists(void);
 

--- a/msr_batch.c
+++ b/msr_batch.c
@@ -31,6 +31,7 @@
 
 #include "msr_batch.h"
 #include "msr_safe.h"
+#include "msr-smp.h"
 #include "msr_allowlist.h"
 
 static struct class *cdev_class;
@@ -73,7 +74,6 @@ static int msrbatch_apply_allowlist(struct msr_batch_array *oa)
     return err;
 }
 
-extern int msr_safe_batch(struct msr_batch_array *oa);
 
 static long msrbatch_ioctl(struct file *f, unsigned int ioc, unsigned long arg)
 {

--- a/msr_batch.c
+++ b/msr_batch.c
@@ -33,6 +33,7 @@
 #include "msr_safe.h"
 #include "msr-smp.h"
 #include "msr_allowlist.h"
+#include "msr_version.h"
 
 static struct class *cdev_class;
 static char cdev_created;
@@ -102,10 +103,18 @@ static long msrbatch_ioctl(struct file *f, unsigned int ioc, unsigned long arg)
         return -EFAULT;
     }
 
-    if (koa.numops <= 0)
+    if (koa.numops == 0)
     {
         pr_debug("Invalid # of ops %d\n", koa.numops);
         return -EINVAL;
+    }
+
+    if ( ((koa.version >> 16) & 0xff) != MSR_SAFE_VERSION_MAJOR ){
+	pr_debug("Version mismatch: loaded is %d, requested is %d\n",
+			MSR_SAFE_VERSION_MAJOR,
+			(koa.version >> 16) & 0xff
+	);
+	return -ENOPROTOOPT;
     }
 
     uops = koa.ops;

--- a/msr_entry.c
+++ b/msr_entry.c
@@ -44,6 +44,7 @@
 #include "msr_batch.h"
 #include "msr_allowlist.h"
 #include "msr_version.h"
+#include "msr_version.h"
 
 static struct class *msr_class;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0)

--- a/msr_entry.c
+++ b/msr_entry.c
@@ -410,5 +410,5 @@ module_exit(msr_exit)
 
 MODULE_AUTHOR("M. Fadden, K. Shoga, B. Rountree, H. P. Anvin");
 MODULE_DESCRIPTION("x86 generic MSR driver (+LLNL Approved List)");
-MODULE_VERSION("1.7");
+MODULE_VERSION( MSR_SAFE_VERSION_STR );
 MODULE_LICENSE("GPL");

--- a/msr_safe.h
+++ b/msr_safe.h
@@ -31,6 +31,7 @@ struct msr_batch_op
 struct msr_batch_array
 {
     __u32 numops;             // In: # of operations in operations array
+    __u32 version;	      // In: MSR_SAFE_VERSION_u32 (see msr_version.h)
     struct msr_batch_op *ops; // In: Array[numops] of operations
 };
 

--- a/msr_version.c
+++ b/msr_version.c
@@ -11,6 +11,7 @@
 #include <linux/version.h>
 #include <linux/module.h>
 #include <linux/uaccess.h>
+#include "msr_version.h"
 
 static struct class *cdev_class;
 static char cdev_created;

--- a/msr_version.c
+++ b/msr_version.c
@@ -50,15 +50,30 @@ static const struct file_operations fops =
     .open = open_version
 };
 
-#if LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,39)
-static char *msr_version_nodename(struct device *dev, mode_t *mode)
-#else
-#if LINUX_VERSION_CODE <= KERNEL_VERSION(6,2,0)
-static char *msr_version_nodename(struct device *dev, umode_t *mode)
-#else
-static char *msr_version_nodename(const struct device *dev, umode_t *mode)
-#endif
-#endif
+#define msr_version_nodename_selector _Generic(\
+        (((struct class *)0)->devnode),\
+        char * (*) (      struct device *,  mode_t *) : msr_version_nodename1,\
+        char * (*) (      struct device *, umode_t *) : msr_version_nodename2,\
+        char * (*) (const struct device *, umode_t *) : msr_version_nodename3 \
+        )
+
+static char *msr_version_nodename1(struct device *dev, mode_t *mode)
+{
+    if (mode)
+    {
+        *mode = 0400;   // read-only
+    }
+    return kasprintf(GFP_KERNEL, "cpu/msr_safe_version");
+}
+static char *msr_version_nodename2(struct device *dev, umode_t *mode)
+{
+    if (mode)
+    {
+        *mode = 0400;   // read-only
+    }
+    return kasprintf(GFP_KERNEL, "cpu/msr_safe_version");
+}
+static char *msr_version_nodename3(const struct device *dev, umode_t *mode)
 {
     if (mode)
     {
@@ -120,7 +135,7 @@ int msr_version_init(int *majordev)
     }
     cdev_class_created = 1;
 
-    cdev_class->devnode = msr_version_nodename;
+    cdev_class->devnode = msr_version_nodename_selector;
 
     dev = device_create(cdev_class, NULL, MKDEV(*majordev, 0), NULL, "msr_safe_version");
     if (IS_ERR(dev))

--- a/msr_version.h
+++ b/msr_version.h
@@ -20,6 +20,6 @@
 
 int msr_version_init(int *majordev);
 
-int msr_version_cleanup(int majordev);
+void msr_version_cleanup(int majordev);
 
 #endif

--- a/msr_version.h
+++ b/msr_version.h
@@ -22,4 +22,26 @@ int msr_version_init(int *majordev);
 
 void msr_version_cleanup(int majordev);
 
+#define MSR_SAFE_VERSION_MAJOR 1
+#define MSR_SAFE_VERSION_MINOR 8
+#define MSR_SAFE_VERSION_PATCH 0
+
+#define MSR_SAFE_VERSION_u32 ( \
+	          ( MSR_SAFE_VERSION_MAJOR << 16 )	\
+		| ( MSR_SAFE_VERSION_MINOR << 8 )	\
+		| ( MSR_SAFE_VERSION_PATCH << 0 ) )
+
+#define MAKESTRING( s ) #s
+#define MAKE_VERSION_STRING(major,minor,patch) \
+	MAKESTRING( major ) 	\
+	"."			\
+	MAKESTRING( minor )	\
+	"."			\
+	MAKESTRING( patch )
+
+#define MSR_SAFE_VERSION_STR MAKE_VERSION_STRING(\
+		MSR_SAFE_VERSION_MAJOR,\
+		MSR_SAFE_VERSION_MINOR,\
+		MSR_SAFE_VERSION_PATCH)
+
 #endif

--- a/msr_version.h
+++ b/msr_version.h
@@ -22,8 +22,8 @@ int msr_version_init(int *majordev);
 
 void msr_version_cleanup(int majordev);
 
-#define MSR_SAFE_VERSION_MAJOR 1
-#define MSR_SAFE_VERSION_MINOR 8
+#define MSR_SAFE_VERSION_MAJOR 2
+#define MSR_SAFE_VERSION_MINOR 0
 #define MSR_SAFE_VERSION_PATCH 0
 
 #define MSR_SAFE_VERSION_u32 ( \

--- a/msrsave/msrsave_main.c
+++ b/msrsave/msrsave_main.c
@@ -14,10 +14,7 @@
 #include <unistd.h>
 
 #include "msrsave.h"
-
-#ifndef VERSION
-#define VERSION "0.0.0"
-#endif
+#include "../msr_version.h"
 
 int main(int argc, char **argv)
 {
@@ -59,7 +56,7 @@ int main(int argc, char **argv)
 
     if (argc > 1 && strncmp(argv[1], "--version", strlen("--version") + 1) == 0)
     {
-        printf("%s\n", VERSION);
+        printf("%s\n", MSR_SAFE_VERSION_STR);
         printf("\nCopyright (C) 2016, Intel Corporation. All rights reserved.\n\n");
         return 0;
     }


### PR DESCRIPTION
 Fixes #169 
 
    Performs version checking.
    
    README.md
    Describes new error (ENOPROTOOP) that results from a mismatch
    between the loaded kernel module and what's in the batch request.
    
    examples/example.c
    Updated to use versioning.
    
    msr_batch.c
    Checks for correct version as part of batch request parsing.
    
    msr_version.h
    Bumped version to 2.0.0.
    
    Tested on serif.
